### PR TITLE
Add port and client args to scripts + minor fixes

### DIFF
--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -94,7 +94,6 @@ def main(client=Client()):
 
 
 if __name__ == '__main__':
-
     p = argparse.ArgumentParser(prog='bootstrap-demo-community', parents=[simple_parser()])
     args = p.parse_args()
 

--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 
+from py_client.arg_parser import simple_parser
 from py_client.client import Client
 from py_client.scheduler import CeremonyPhase
 from py_client.ipfs import Ipfs, ICONS_PATH
@@ -93,15 +94,8 @@ def main(client=Client()):
 
 
 if __name__ == '__main__':
-    default_client = '../target/release/encointer-client-notee'
 
-    p = argparse.ArgumentParser(prog='bootstrap-demo-community')
-    p.add_argument('--client',
-                   default=default_client,
-                   help=f'The rust client binary that should be used. (default={default_client})')
-    p.add_argument('--port',
-                   default=9944,
-                   help='Port of the node (default=9944).')
+    p = argparse.ArgumentParser(prog='bootstrap-demo-community', parents=[simple_parser()])
     args = p.parse_args()
 
     print(f"Starting script with client '{args.client}' on port {args.port}")

--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 import argparse
 import json
 

--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -1,4 +1,5 @@
 #!python
+import argparse
 import json
 
 from py_client.client import Client
@@ -92,4 +93,17 @@ def main(client=Client()):
 
 
 if __name__ == '__main__':
-    main()
+    default_client = '../target/release/encointer-client-notee'
+
+    p = argparse.ArgumentParser(prog='bootstrap-demo-community')
+    p.add_argument('--client',
+                   default=default_client,
+                   help=f'The rust client binary that should be used. (default={default_client})')
+    p.add_argument('--port',
+                   default=9944,
+                   help='Port of the node (default=9944).')
+    args = p.parse_args()
+
+    print(f"Starting script with client '{args.client}' on port {args.port}")
+
+    main(Client(rust_client=args.client, port=args.port))

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -119,7 +119,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='bot-community', parents=[simple_parser()])
     subparsers = parser.add_subparsers(dest='subparser', help='sub-command help')
 
-    # note: the function args' names' `client` and `port` must match the cli's args' names.
+    # Note: the function args' names `client` and `port` must match the cli's args' names.
     # Otherwise, the the values can't be extracted from the `**kwargs`.
     parser_a = subparsers.add_parser('init', help='a help')
     parser_b = subparsers.add_parser('run', help='b help')

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 import argparse
 import itertools
 

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -35,7 +35,7 @@ def init_bootstrappers(client=Client()):
     return bootstrappers
 
 
-def init(client, port):
+def init(client: str, port: str):
     client = Client(rust_client=client, port=port)
     ipfs_cid = Ipfs.add_recursive(ICONS_PATH)
     print("initializing community")
@@ -49,7 +49,7 @@ def init(client, port):
     f.close()
 
 
-def register_participants(client, accounts, cid):
+def register_participants(client: Client, accounts, cid):
     bal = [client.balance(a, cid=cid) for a in accounts]
     total = sum(bal)
     print("****** money supply is " + str(total))
@@ -73,7 +73,7 @@ def register_participants(client, accounts, cid):
         client.register_participant(p, cid)
 
 
-def perform_meetup(client, meetup, cid):
+def perform_meetup(client: Client, meetup, cid):
     n = len(meetup)
     print("Performing meetup with " + str(n) + " participants")
 
@@ -85,7 +85,7 @@ def perform_meetup(client, meetup, cid):
         client.attest_claims(attestor, attestees_claims)
 
 
-def run(client, port):
+def run(client: str, port: int):
     client = Client(rust_client=client, port=port)
     f = open("cid.txt", "r")
     cid = f.read()
@@ -105,18 +105,22 @@ def run(client, port):
         client.await_block()
 
 
-def benchmark(client, port):
+def benchmark(client: str, port: int):
+    py_client = Client(rust_client=client, port=port)
     print("will grow population forever")
     while True:
         run(client, port)
-        client.await_block()
-        client.next_phase()
-        client.await_block()
+        py_client.await_block()
+        py_client.next_phase()
+        py_client.await_block()
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='bot-community', parents=[simple_parser()])
     subparsers = parser.add_subparsers(dest='subparser', help='sub-command help')
+
+    # note: the function args' names' `client` and `port` must match the cli's args' names.
+    # Otherwise, the the values can't be extracted from the `**kwargs`.
     parser_a = subparsers.add_parser('init', help='a help')
     parser_b = subparsers.add_parser('run', help='b help')
     parser_c = subparsers.add_parser('benchmark', help='b help')

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 import argparse
-import itertools
 
 import geojson
 
 from random_words import RandomWords
 from math import floor
 
+from py_client.arg_parser import simple_parser
 from py_client.client import Client
 from py_client.ipfs import Ipfs, ICONS_PATH
 from py_client.communities import populate_locations, generate_community_spec, meta_json
@@ -35,7 +35,8 @@ def init_bootstrappers(client=Client()):
     return bootstrappers
 
 
-def init(client=Client()):
+def init(client, port):
+    client = Client(rust_client=client, port=port)
     ipfs_cid = Ipfs.add_recursive(ICONS_PATH)
     print("initializing community")
     b = init_bootstrappers(client)
@@ -84,7 +85,8 @@ def perform_meetup(client, meetup, cid):
         client.attest_claims(attestor, attestees_claims)
 
 
-def run(client=Client()):
+def run(client, port):
+    client = Client(rust_client=client, port=port)
     f = open("cid.txt", "r")
     cid = f.read()
     print("cid is " + cid)
@@ -103,18 +105,17 @@ def run(client=Client()):
         client.await_block()
 
 
-def benchmark():
+def benchmark(client, port):
     print("will grow population forever")
-    client = Client()
     while True:
-        run()
+        run(client, port)
         client.await_block()
         client.next_phase()
         client.await_block()
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(prog='bot-community')
+    parser = argparse.ArgumentParser(prog='bot-community', parents=[simple_parser()])
     subparsers = parser.add_subparsers(dest='subparser', help='sub-command help')
     parser_a = subparsers.add_parser('init', help='a help')
     parser_b = subparsers.add_parser('run', help='b help')

--- a/client/py_client/arg_parser.py
+++ b/client/py_client/arg_parser.py
@@ -1,6 +1,6 @@
 import argparse
 
-default_client = '../target/release/encointer-client-notee'
+DEFAULT_CLIENT = '../target/release/encointer-client-notee'
 
 
 def simple_parser(add_help=False):
@@ -13,8 +13,8 @@ def simple_parser(add_help=False):
 
     p = argparse.ArgumentParser(add_help=add_help)
     p.add_argument('--client',
-                   default=default_client,
-                   help=f'The rust client binary that should be used. (default={default_client})')
+                   default=DEFAULT_CLIENT,
+                   help=f'The rust client binary that should be used. (default={DEFAULT_CLIENT})')
     p.add_argument('--port',
                    default=9944,
                    help='Port of the node (default=9944).')

--- a/client/py_client/arg_parser.py
+++ b/client/py_client/arg_parser.py
@@ -1,0 +1,21 @@
+import argparse
+
+default_client = '../target/release/encointer-client-notee'
+
+
+def simple_parser(add_help=False):
+    """ Create a simple parser that adds [client] and [port] arguments.
+
+        Help must be false if the parser is passed as a parent to another parser
+        to prevent duplicate declaration. But the `simple_parser`s arguments
+        will be shown regardless.
+    """
+
+    p = argparse.ArgumentParser(add_help=add_help)
+    p.add_argument('--client',
+                   default=default_client,
+                   help=f'The rust client binary that should be used. (default={default_client})')
+    p.add_argument('--port',
+                   default=9944,
+                   help='Port of the node (default=9944).')
+    return p

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1080,6 +1080,7 @@ fn get_meetup_location(api: &Api<sr25519::Pair>, cid: CommunityIdentifier, minde
     Some(locations[lidx])
 }
 
+/// This rpc needs to have offchain indexing enabled in the node.
 fn get_cid_names(api: &Api<sr25519::Pair>) -> Option<Vec<CidName>> {
     let req = json!({
         "method": "communities_getAll",
@@ -1088,7 +1089,8 @@ fn get_cid_names(api: &Api<sr25519::Pair>) -> Option<Vec<CidName>> {
         "id": "1",
     });
 
-    let n = api.get_request(req.to_string()).unwrap().unwrap();
+    let n = api.get_request(req.to_string()).unwrap()
+        .expect("No communities returned. Are you running the node with `--enable-offchain-indexing true`?");
     Some(serde_json::from_str(&n).unwrap())
 }
 


### PR DESCRIPTION
* add `port` and `client` arg to bootstrap_demo_community.py and bot-community.py. Closes #68.
* [client] More meaningful error panic message for `get_cid_names`.
* fix linux python shebang.