### PR TITLE
Fix bazaar rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "encointer-primitives"
 version = "0.6.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f057d530c95f77bca5a90ff9356dbe1c1286a477"
+source = "git+https://github.com/encointer/pallets?branch=master#cfd318ef91d18059ad61881fe2bdae69e42252ae"
 dependencies = [
  "parity-scale-codec 2.1.1",
  "serde",
@@ -4137,7 +4137,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-balances"
 version = "0.6.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f057d530c95f77bca5a90ff9356dbe1c1286a477"
+source = "git+https://github.com/encointer/pallets?branch=master#cfd318ef91d18059ad61881fe2bdae69e42252ae"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4158,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar"
 version = "0.6.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f057d530c95f77bca5a90ff9356dbe1c1286a477"
+source = "git+https://github.com/encointer/pallets?branch=master#cfd318ef91d18059ad61881fe2bdae69e42252ae"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4173,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f057d530c95f77bca5a90ff9356dbe1c1286a477"
+source = "git+https://github.com/encointer/pallets?branch=master#cfd318ef91d18059ad61881fe2bdae69e42252ae"
 dependencies = [
  "encointer-primitives",
  "jsonrpc-core",
@@ -4191,7 +4191,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f057d530c95f77bca5a90ff9356dbe1c1286a477"
+source = "git+https://github.com/encointer/pallets?branch=master#cfd318ef91d18059ad61881fe2bdae69e42252ae"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies"
 version = "0.6.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f057d530c95f77bca5a90ff9356dbe1c1286a477"
+source = "git+https://github.com/encointer/pallets?branch=master#cfd318ef91d18059ad61881fe2bdae69e42252ae"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities"
 version = "0.6.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f057d530c95f77bca5a90ff9356dbe1c1286a477"
+source = "git+https://github.com/encointer/pallets?branch=master#cfd318ef91d18059ad61881fe2bdae69e42252ae"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f057d530c95f77bca5a90ff9356dbe1c1286a477"
+source = "git+https://github.com/encointer/pallets?branch=master#cfd318ef91d18059ad61881fe2bdae69e42252ae"
 dependencies = [
  "encointer-primitives",
  "jsonrpc-core",
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f057d530c95f77bca5a90ff9356dbe1c1286a477"
+source = "git+https://github.com/encointer/pallets?branch=master#cfd318ef91d18059ad61881fe2bdae69e42252ae"
 dependencies = [
  "encointer-primitives",
  "sp-api",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-scheduler"
 version = "0.6.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f057d530c95f77bca5a90ff9356dbe1c1286a477"
+source = "git+https://github.com/encointer/pallets?branch=master#cfd318ef91d18059ad61881fe2bdae69e42252ae"
 dependencies = [
  "encointer-primitives",
  "frame-support",

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -8,6 +8,7 @@
 use std::sync::Arc;
 
 use encointer_node_notee_runtime::{opaque::Block, AccountId, Balance, Index};
+use pallet_encointer_bazaar_rpc::{Bazaar, BazaarApi};
 pub use sc_rpc_api::DenyUnsafe;
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
@@ -42,6 +43,7 @@ where
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: BlockBuilder<Block>,
 	C::Api: pallet_encointer_communities_rpc_runtime_api::CommunitiesApi<Block>,
+	C::Api: pallet_encointer_bazaar_rpc_runtime_api::BazaarApi<Block, AccountId>,
 	P: TransactionPool + 'static,
 	TBackend: sc_client_api::Backend<Block>,
 	<TBackend as sc_client_api::Backend<Block>>::OffchainStorage: 'static,
@@ -56,6 +58,8 @@ where
 	io.extend_with(SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe)));
 
 	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(client.clone())));
+
+	io.extend_with(BazaarApi::to_delegate(Bazaar::new(client.clone(), deny_unsafe)));
 
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed


### PR DESCRIPTION
The bazaar rpc-extensions were not actually added to the rpc before.

Here we:
* actually add them to rpc
* bump the pallets, which include a fix that was not discovered before because the rpc was not added.

Todo:
- [x] First merge #90 
- [x] Rebase on master
- [x] retarget this pr to master