### PR TITLE
Extract cli args definitions from client

### DIFF
--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -78,8 +78,6 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 	}
 }
 
---
-
 impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 	fn account_arg(&self) -> Option<&str> {
 		self.value_of(ACCOUNT_ARG)

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -2,15 +2,21 @@ use clap::{App, Arg, ArgMatches};
 
 const ACCOUNT_ARG: &'static str = "accountid";
 const SIGNER_ARG: &'static str = "signer";
+const CLAIMS_ARG: &'static str = "claims";
+const CEREMONY_INDEX_ARG: &'static str = "ceremony-index";
 
 pub trait EncointerArgs<'b> {
 	fn account_arg(self) -> Self;
 	fn signer_arg(self, help: &'b str) -> Self;
+	fn claims_arg(self) -> Self;
+	fn ceremony_index_arg(self) -> Self;
 }
 
 pub trait EncointerArgsExtractor {
 	fn account_arg(&self) -> Option<&str>;
 	fn signer_arg(&self) -> Option<&str>;
+	fn claims_arg(&self) -> Option<Vec<&str>>;
+	fn ceremony_index_arg(&self) -> Option<&str>;
 }
 
 impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
@@ -33,6 +39,28 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 				.help(help),
 		)
 	}
+
+	fn claims_arg(self) -> Self {
+		self.arg(
+			Arg::with_name(CLAIMS_ARG)
+				.takes_value(true)
+				.required(true)
+				.multiple(true)
+				.min_values(2),
+		)
+	}
+
+	fn ceremony_index_arg(self) -> Self {
+		self.arg(
+			Arg::with_name(CEREMONY_INDEX_ARG)
+				.takes_value(true)
+				.allow_hyphen_values(true)
+				.default_value("-1")
+				.help(
+					"If positive, absolute index. If negative, current_index -i. 0 is not allowed",
+				),
+		)
+	}
 }
 
 impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
@@ -42,5 +70,13 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 
 	fn signer_arg(&self) -> Option<&str> {
 		self.value_of(SIGNER_ARG)
+	}
+
+	fn claims_arg(&self) -> Option<Vec<&str>> {
+		self.values_of(CLAIMS_ARG).map(|c| c.collect())
+	}
+
+	fn ceremony_index_arg(&self) -> Option<&str> {
+		self.value_of(CEREMONY_INDEX_ARG)
 	}
 }

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -45,7 +45,7 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 
 	fn optional_cid_arg(self) -> Self {
 		self.arg(
-			Arg::with_name("cid")
+			Arg::with_name(CID_ARG)
 				.short("c")
 				.long("cid")
 				.global(true)

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -1,16 +1,19 @@
 use clap::{App, Arg, ArgMatches};
 
-const ACCOUNT_ARG: &'static str = "AccountId";
+const ACCOUNT_ARG: &'static str = "accountid";
+const SIGNER_ARG: &'static str = "signer";
 
-pub trait EncointerArgs {
+pub trait EncointerArgs<'b> {
 	fn account_arg(self) -> Self;
+	fn signer_arg(self, help: &'b str) -> Self;
 }
 
 pub trait EncointerArgsExtractor {
 	fn account_arg(&self) -> Option<&str>;
+	fn signer_arg(&self) -> Option<&str>;
 }
 
-impl<'a, 'b> EncointerArgs for App<'a, 'b> {
+impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 	fn account_arg(self) -> Self {
 		self.arg(
 			Arg::with_name(ACCOUNT_ARG)
@@ -20,10 +23,24 @@ impl<'a, 'b> EncointerArgs for App<'a, 'b> {
 				.help("AccountId in ss58check format"),
 		)
 	}
+
+	fn signer_arg(self, help: &'b str) -> Self {
+		self.arg(
+			Arg::with_name(SIGNER_ARG)
+				.takes_value(true)
+				.required(true)
+				.value_name("SS58")
+				.help(help),
+		)
+	}
 }
 
 impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 	fn account_arg(&self) -> Option<&str> {
 		self.value_of(ACCOUNT_ARG)
+	}
+
+	fn signer_arg(&self) -> Option<&str> {
+		self.value_of(SIGNER_ARG)
 	}
 }

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -2,12 +2,14 @@ use clap::{App, Arg, ArgMatches};
 
 const ACCOUNT_ARG: &'static str = "accountid";
 const SIGNER_ARG: &'static str = "signer";
+const CID_ARG: &'static str = "cid";
 const CLAIMS_ARG: &'static str = "claims";
 const CEREMONY_INDEX_ARG: &'static str = "ceremony-index";
 
 pub trait EncointerArgs<'b> {
 	fn account_arg(self) -> Self;
 	fn signer_arg(self, help: &'b str) -> Self;
+	fn optional_cid_arg(self) -> Self;
 	fn claims_arg(self) -> Self;
 	fn ceremony_index_arg(self) -> Self;
 }
@@ -15,6 +17,7 @@ pub trait EncointerArgs<'b> {
 pub trait EncointerArgsExtractor {
 	fn account_arg(&self) -> Option<&str>;
 	fn signer_arg(&self) -> Option<&str>;
+	fn cid_arg(&self) -> Option<&str>;
 	fn claims_arg(&self) -> Option<Vec<&str>>;
 	fn ceremony_index_arg(&self) -> Option<&str>;
 }
@@ -37,6 +40,18 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 				.required(true)
 				.value_name("SS58")
 				.help(help),
+		)
+	}
+
+	fn optional_cid_arg(self) -> Self {
+		self.arg(
+			Arg::with_name("cid")
+				.short("c")
+				.long("cid")
+				.global(true)
+				.takes_value(true)
+				.value_name("STRING")
+				.help("community identifier, base58 encoded"),
 		)
 	}
 
@@ -70,6 +85,10 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 
 	fn signer_arg(&self) -> Option<&str> {
 		self.value_of(SIGNER_ARG)
+	}
+
+	fn cid_arg(&self) -> Option<&str> {
+		self.value_of(CID_ARG)
 	}
 
 	fn claims_arg(&self) -> Option<Vec<&str>> {

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -78,6 +78,8 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 	}
 }
 
+--
+
 impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 	fn account_arg(&self) -> Option<&str> {
 		self.value_of(ACCOUNT_ARG)

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -1,0 +1,29 @@
+use clap::{App, Arg, ArgMatches};
+
+const ACCOUNT_ARG: &'static str = "AccountId";
+
+pub trait EncointerArgs {
+	fn account_arg(self) -> Self;
+}
+
+pub trait EncointerArgsExtractor {
+	fn account_arg(&self) -> Option<&str>;
+}
+
+impl<'a, 'b> EncointerArgs for App<'a, 'b> {
+	fn account_arg(self) -> Self {
+		self.arg(
+			Arg::with_name(ACCOUNT_ARG)
+				.takes_value(true)
+				.required(true)
+				.value_name("SS58")
+				.help("AccountId in ss58check format"),
+		)
+	}
+}
+
+impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
+	fn account_arg(&self) -> Option<&str> {
+		self.value_of(ACCOUNT_ARG)
+	}
+}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -625,20 +625,14 @@ fn main() {
                     app.setting(AppSettings::ColoredHelp)
                         .setting(AppSettings::AllowLeadingHyphen)
                         .account_arg()
-                        .arg(
-                            Arg::with_name("ceremony-index")
-                                .takes_value(true)
-                                .allow_hyphen_values(true)
-                                .default_value("-1")
-                                .help("If positive, absolute index. If negative, current_index -i. 0 is not allowed"),
-                    )
+                        .ceremony_index_arg()
                 })
                 .runner(move |_args: &str, matches: &ArgMatches<'_>| {
                     let arg_who = matches.account_arg().unwrap();
                     let accountid = get_accountid_from_str(arg_who);
                     let api = get_chain_api(matches);
 
-                    let index: i32 = matches.value_of("ceremony-index").unwrap().parse().unwrap();
+                    let index: i32 = matches.ceremony_index_arg().unwrap().parse().unwrap();
                     let cindex = match index {
                         i32::MIN..=-1 => get_ceremony_index(&api) - index.abs() as u32,
                         1..=i32::MAX => index as u32,
@@ -664,18 +658,12 @@ fn main() {
                 .options(|app| {
                     app.setting(AppSettings::ColoredHelp)
                     .account_arg()
-                    .arg(
-                        Arg::with_name("claims")
-                            .takes_value(true)
-                            .required(true)
-                            .multiple(true)
-                            .min_values(2)
-                    )
+                    .claims_arg()
                 })
                 .runner(move |_args: &str, matches: &ArgMatches<'_>| {
                     let arg_who = matches.account_arg().unwrap();
                     let who = get_pair_from_str(arg_who);
-                    let claims_arg: Vec<_> = matches.values_of("claims").unwrap().collect();
+                    let claims_arg: Vec<_> = matches.claims_arg().unwrap();
                     let mut claims: Vec<ClaimOfAttendance<MultiSignature, AccountId, Moment>> = vec![];
                     for arg in claims_arg.iter() {
                         let w = ClaimOfAttendance::decode(&mut &hex::decode(arg).unwrap()[..]).unwrap();

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -19,6 +19,8 @@
 //! encointer-client-notee transfer //Alice 5G9RtsTbiYJYQYMHbWfyPoeuuxNaCbC16tZ2JGrZ4gRKwz14 1000
 //!
 
+mod cli_args;
+
 #[macro_use]
 extern crate clap;
 extern crate env_logger;
@@ -40,6 +42,7 @@ use sp_runtime::{
 	MultiSignature,
 };
 
+use cli_args::{EncointerArgs, EncointerArgsExtractor};
 use encointer_node_notee_runtime::{
 	AccountId, BalanceEntry, BalanceType, BlockNumber, Event, Hash, Header, Moment, Signature,
 	ONE_DAY,
@@ -213,17 +216,11 @@ fn main() {
                 .description("query on-chain balance for AccountId. If --cid is supplied, returns balance in that community. Otherwise balance of native ERT token")
                 .options(|app| {
                     app.setting(AppSettings::ColoredHelp)
-                    .arg(
-                        Arg::with_name("AccountId")
-                            .takes_value(true)
-                            .required(true)
-                            .value_name("SS58")
-                            .help("AccountId in ss58check format"),
-                    )
+                    .account_arg()
                 })
                 .runner(|_args: &str, matches: &ArgMatches<'_>| {
                     let api = get_chain_api(matches);
-                    let account = matches.value_of("AccountId").unwrap();
+                    let account = matches.account_arg().unwrap();
                     let accountid = get_accountid_from_str(account);
                     match matches.value_of("cid") {
                         Some(cid_str) => {
@@ -586,16 +583,10 @@ fn main() {
                 .description("register encointer ceremony participant for supplied community")
                 .options(|app| {
                     app.setting(AppSettings::ColoredHelp)
-                    .arg(
-                        Arg::with_name("accountid")
-                            .takes_value(true)
-                            .required(true)
-                            .value_name("SS58")
-                            .help("AccountId in ss58check format"),
-                    )
+                    .account_arg()
                 })
                 .runner(move |_args: &str, matches: &ArgMatches<'_>| {
-                    let arg_who = matches.value_of("accountid").unwrap();
+                    let arg_who = matches.account_arg().unwrap();
                     let accountid = get_accountid_from_str(arg_who);
                     let signer = get_pair_from_str(arg_who);
                     let api = get_chain_api(matches);
@@ -638,13 +629,7 @@ fn main() {
                 .options(|app| {
                     app.setting(AppSettings::ColoredHelp)
                         .setting(AppSettings::AllowLeadingHyphen)
-                        .arg(
-                            Arg::with_name("accountid")
-                                .takes_value(true)
-                                .required(true)
-                                .value_name("SS58")
-                                .help("AccountId in ss58check format"),
-                        )
+                        .account_arg()
                         .arg(
                             Arg::with_name("ceremony-index")
                                 .takes_value(true)
@@ -654,7 +639,7 @@ fn main() {
                     )
                 })
                 .runner(move |_args: &str, matches: &ArgMatches<'_>| {
-                    let arg_who = matches.value_of("accountid").unwrap();
+                    let arg_who = matches.account_arg().unwrap();
                     let accountid = get_accountid_from_str(arg_who);
                     let api = get_chain_api(matches);
 
@@ -683,13 +668,7 @@ fn main() {
                 .description("register encointer ceremony claim of attendances for supplied community")
                 .options(|app| {
                     app.setting(AppSettings::ColoredHelp)
-                    .arg(
-                        Arg::with_name("accountid")
-                            .takes_value(true)
-                            .required(true)
-                            .value_name("SS58")
-                            .help("AccountId in ss58check format"),
-                    )
+                    .account_arg()
                     .arg(
                         Arg::with_name("claims")
                             .takes_value(true)
@@ -699,7 +678,7 @@ fn main() {
                     )
                 })
                 .runner(move |_args: &str, matches: &ArgMatches<'_>| {
-                    let arg_who = matches.value_of("accountid").unwrap();
+                    let arg_who = matches.account_arg().unwrap();
                     let who = get_pair_from_str(arg_who);
                     let claims_arg: Vec<_> = matches.values_of("claims").unwrap().collect();
                     let mut claims: Vec<ClaimOfAttendance<MultiSignature, AccountId, Moment>> = vec![];
@@ -726,13 +705,7 @@ fn main() {
                 .description("create a fresh claim of attendance for account")
                 .options(|app| {
                     app.setting(AppSettings::ColoredHelp)
-                    .arg(
-                        Arg::with_name("accountid")
-                            .takes_value(true)
-                            .required(true)
-                            .value_name("ACCOUNT")
-                            .help("AccountId in ss58check format"),
-                    )
+                    .account_arg()
                     .arg(
                         Arg::with_name("vote")
                             .takes_value(true)
@@ -743,7 +716,7 @@ fn main() {
                 })
                 .runner(move |_args: &str, matches: &ArgMatches<'_>| {
                     debug!("{:?}", matches);
-                    let arg_who = matches.value_of("accountid").unwrap();
+                    let arg_who = matches.account_arg().unwrap();
                     let claimant = get_pair_from_str(arg_who);
                     let api = get_chain_api(matches);
                     let cid = verify_cid(&api,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -349,12 +349,7 @@ fn main() {
                             .required(true)
                             .help("enhanced geojson file that specifies a community"),
                     )
-                    .arg(
-                        Arg::with_name("signer")
-                            .takes_value(true)
-                            .required(true)
-                            .help("a bootstrapper account to sign the registration extrinsic"),
-                    )
+                    .signer_arg("a bootstrapper account to sign the registration extrinsic")
                 })
                 .runner(|_args: &str, matches: &ArgMatches<'_>| {
                     let p_arg = matches.value_of("signer").unwrap();

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -101,15 +101,7 @@ fn main() {
                     .default_value("9944")
                     .help("node port"),
             )
-            .arg(
-                Arg::with_name("cid")
-                    .short("c")
-                    .long("cid")
-                    .global(true)
-                    .takes_value(true)
-                    .value_name("STRING")
-                    .help("community identifier, base58 encoded"),
-                )
+            .optional_cid_arg()
             .name("encointer-client-notee")
             .version(VERSION)
             .author("Encointer Association <info@encointer.org>")
@@ -222,7 +214,7 @@ fn main() {
                     let api = get_chain_api(matches);
                     let account = matches.account_arg().unwrap();
                     let accountid = get_accountid_from_str(account);
-                    match matches.value_of("cid") {
+                    match matches.cid_arg() {
                         Some(cid_str) => {
                             let cid = verify_cid(&api, cid_str);
                             let bn = get_block_number(&api);
@@ -281,7 +273,7 @@ fn main() {
                     info!("from ss58 is {}", from.public().to_ss58check());
                     info!("to ss58 is {}", to.to_ss58check());
                     let _api = api.set_signer(sr25519_core::Pair::from(from));
-                    let tx_hash = match matches.value_of("cid") {
+                    let tx_hash = match matches.cid_arg() {
                         Some(cid_str) => {
                             let cid = verify_cid(&_api, cid_str);
                             let amount = BalanceType::from_str(matches.value_of("amount").unwrap())
@@ -479,8 +471,7 @@ fn main() {
                     let api = get_chain_api(matches);
                     let cindex = get_ceremony_index(&api);
                     let cid = verify_cid(&api,
-                        matches
-                            .value_of("cid")
+                        matches.cid_arg()
                             .expect("please supply argument --cid"),
                     );
                     println!(
@@ -505,7 +496,7 @@ fn main() {
                     let cindex = get_ceremony_index(&api);
                     let cid = verify_cid(&api,
                         matches
-                            .value_of("cid")
+                            .cid_arg()
                             .expect("please supply argument --cid"),
                     );
                     println!(
@@ -541,7 +532,7 @@ fn main() {
                     let cindex = get_ceremony_index(&api);
                     let cid = verify_cid(&api,
                         matches
-                            .value_of("cid")
+                            .cid_arg()
                             .expect("please supply argument --cid"),
                     );
                     println!(
@@ -588,7 +579,7 @@ fn main() {
                     let cindex = get_ceremony_index(&api);
                     let cid = verify_cid(&api,
                         matches
-                            .value_of("cid")
+                            .cid_arg()
                             .expect("please supply argument --cid"),
                     );
                     let rep = get_reputation(&api, &accountid, cid, cindex -1);
@@ -641,7 +632,7 @@ fn main() {
 
                     let cid = verify_cid(
                         &api,
-                     matches.value_of("cid").expect("please supply argument --cid"),
+                     matches.cid_arg().expect("please supply argument --cid"),
                     );
 
                     debug!("Getting proof for ceremony index: {:?}", cindex);
@@ -704,7 +695,7 @@ fn main() {
                     let api = get_chain_api(matches);
                     let cid = verify_cid(&api,
                         matches
-                            .value_of("cid")
+                            .cid_arg()
                             .expect("please supply argument --cid"),
                     );
                     let n_participants = matches


### PR DESCRIPTION
I did this now because I can see that for #88, I will reuse the same cli-args several times.

In my opinion, this increases readability. This does not include every cli arg yet. I left some that are only used once in the client due to time constraints, and I first want to feel if it is even a good approach. 

After finishing #88, I will formulate a proper client refactoring task, which can be done step-wise.