### PR TITLE
Use click for python cli parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
       run: |
         cd client
         python bot-community.py init
-        python bot-community.py run
+        python bot-community.py execute-current-phase
 
   test-bazaar:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,4 +229,4 @@ jobs:
         run: |
           cd client
           python bot-community.py init
-          python register-businesses.py
+          python register-businesses.py register

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,4 +229,4 @@ jobs:
         run: |
           cd client
           python bot-community.py init
-          python register-businesses.py register
+          python register-businesses.py

--- a/client/README.md
+++ b/client/README.md
@@ -49,15 +49,21 @@ listen to chain events for debugging (i.e. see failed extrinsics)
 RUST_LOG=encointer_client_notee=info ./target/release/encointer-client-notee listen
 ```
 
+run a single cycle
+```bash
+cd client
+./bot-community.py run
+```
+
 benchmark bot community
 ```bash
 cd client
-./bot-community.py init
+./bot-community.py benchmark
 ```
 
 if you'd like to test bazaar with dummy businesses and offerings too, you need to provide IPFS.
 
-either through infura:
+either through infura
 
 ```
 export IPFS_ADD_URL=https://ipfs.infura.io:5001/api/v0/add
@@ -66,7 +72,7 @@ export IPFS_API_KEY=<user>:<password>
 ./register-businesses.py
 ```
 
-or locally:
+or locally
 
 ```
 # you may need to run 'ipfs init'
@@ -74,3 +80,17 @@ ipfs daemon
 ./bot-communities.py init --ipfs-local
 ./register-businesses.py  --ipfs-local
 ```
+
+In IPFS, the community icons and data of businesses and offerings are stored.
+## Notes
+
+The cli provides helpful information for the ordering of options and commands. <br>
+You can use a custom chain client by providing the option before the command
+```
+./bot-communities.py --client ./path/to/custom/client init
+```
+You can also connect to a remote chain
+```
+./bot-communities.py init --node_url wss://remote.node.org
+```
+For now, the node_url is hardcoded to 'wss://gesell.encointer.org' despite which value you enter. This will be changed in the future when more remote chains will be available. 

--- a/client/README.md
+++ b/client/README.md
@@ -49,7 +49,7 @@ listen to chain events for debugging (i.e. see failed extrinsics)
 RUST_LOG=encointer_client_notee=info ./target/release/encointer-client-notee listen
 ```
 
-run a single cycle
+run a single phase
 ```bash
 cd client
 ./bot-community.py run
@@ -85,24 +85,12 @@ In IPFS, the community icons and data of businesses and offerings are stored.
 
 You can cat/get the data stored in ipfs locally:
 ```
-ipfs cat CONTENT_IDENTIFIER
+ipfs cat <CONTENT_IDENTIFIER>
 ```
 Or if it was stored remotely (on Infura):
 ```
-curl -X POST "https://ipfs.infura.io:5001/api/v0/cat?arg=QmaS7notdEkVmFvL2E19r8bpcVjdgjEV3gu6C2jYqUS1UB" 
+curl -X POST "https://ipfs.infura.io:5001/api/v0/cat?arg=<CONTENT_IDENTIFIER>" 
 ```
 ## Notes
 
-The cli provides helpful information for the ordering of options and commands. <br>
-The following options exist:
-* <kbd>--client</kbd> --> (string) path/to/chain/client
-* <kbd>--port</kbd> --> (string) specify port for the chain client
-* <kbd>-l,--ipfs_local</kbd> --> (bool) choose local ipfs node
-* <kbd>--node_url</kbd> --> (string) choose local ipfs node
-
-A possible call would look like
-
-```
-./bot-communities.py --client ./path/to/custom/client --port 123 -l --node_url wss://gesell.encointer.org init
-```
 For now, the node_url is hardcoded to 'wss://gesell.encointer.org' and port 443 is automatically set despite which value you enter. This will be changed in the future when more remote chains will be available. 

--- a/client/README.md
+++ b/client/README.md
@@ -69,7 +69,7 @@ either through infura
 export IPFS_ADD_URL=https://ipfs.infura.io:5001/api/v0/add
 export IPFS_API_KEY=<user>:<password>
 ./bot-communities.py init
-./register-businesses.py register
+./register-businesses.py
 ```
 
 or locally
@@ -78,10 +78,19 @@ or locally
 # you may need to run 'ipfs init'
 ipfs daemon
 ./bot-communities.py --ipfs-local init 
-./register-businesses.py --ipfs-local register
+./register-businesses.py --ipfs-local
 ```
 
 In IPFS, the community icons and data of businesses and offerings are stored.
+
+You can cat/get the data stored in ipfs locally:
+```
+ipfs cat CONTENT_IDENTIFIER
+```
+Or if it was stored remotely (on Infura):
+```
+curl -X POST "https://ipfs.infura.io:5001/api/v0/cat?arg=QmaS7notdEkVmFvL2E19r8bpcVjdgjEV3gu6C2jYqUS1UB" 
+```
 ## Notes
 
 The cli provides helpful information for the ordering of options and commands. <br>

--- a/client/README.md
+++ b/client/README.md
@@ -91,6 +91,3 @@ Or if it was stored remotely (on Infura):
 ```
 curl -X POST "https://ipfs.infura.io:5001/api/v0/cat?arg=<CONTENT_IDENTIFIER>" 
 ```
-## Notes
-
-For now, the node_url is hardcoded to 'wss://gesell.encointer.org' and port 443 is automatically set despite which value you enter. This will be changed in the future when more remote chains will be available. 

--- a/client/README.md
+++ b/client/README.md
@@ -69,7 +69,7 @@ either through infura
 export IPFS_ADD_URL=https://ipfs.infura.io:5001/api/v0/add
 export IPFS_API_KEY=<user>:<password>
 ./bot-communities.py init
-./register-businesses.py
+./register-businesses.py register
 ```
 
 or locally
@@ -77,20 +77,23 @@ or locally
 ```
 # you may need to run 'ipfs init'
 ipfs daemon
-./bot-communities.py init --ipfs-local
-./register-businesses.py  --ipfs-local
+./bot-communities.py --ipfs-local init 
+./register-businesses.py --ipfs-local register
 ```
 
 In IPFS, the community icons and data of businesses and offerings are stored.
 ## Notes
 
 The cli provides helpful information for the ordering of options and commands. <br>
-You can use a custom chain client by providing the option before the command
+The following options exist:
+* <kbd>--client</kbd> --> (string) path/to/chain/client
+* <kbd>--port</kbd> --> (string) specify port for the chain client
+* <kbd>-l,--ipfs_local</kbd> --> (bool) choose local ipfs node
+* <kbd>--node_url</kbd> --> (string) choose local ipfs node
+
+A possible call would look like
+
 ```
-./bot-communities.py --client ./path/to/custom/client init
+./bot-communities.py --client ./path/to/custom/client --port 123 -l --node_url wss://gesell.encointer.org init
 ```
-You can also connect to a remote chain
-```
-./bot-communities.py init --node_url wss://remote.node.org
-```
-For now, the node_url is hardcoded to 'wss://gesell.encointer.org' despite which value you enter. This will be changed in the future when more remote chains will be available. 
+For now, the node_url is hardcoded to 'wss://gesell.encointer.org' and port 443 is automatically set despite which value you enter. This will be changed in the future when more remote chains will be available. 

--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -54,8 +54,8 @@ def update_spec_with_cid(file, cid):
 
 
 @click.command()
-@click.option('--client', default='../target/release/encointer-client-notee', help='the client to communicate with the chain')
-@click.option('--port', default='9944', help='port for the client to communicate with chain')
+@click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
+@click.option('--port', default='9944', help='ws-port of the chain.')
 @click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used')
 def main(ipfs_local, client, port):
     client = Client(rust_client=client, port=port)

--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -10,11 +10,10 @@ then run this script
 
 """
 
-import argparse
 import json
 import os
+import click
 
-from py_client.arg_parser import simple_parser
 from py_client.client import Client
 from py_client.scheduler import CeremonyPhase
 from py_client.ipfs import Ipfs, ICONS_PATH
@@ -54,7 +53,12 @@ def update_spec_with_cid(file, cid):
         spec_json.truncate()
 
 
-def main(ipfs_local, client=Client()):
+@click.command()
+@click.option('--client', default='../target/release/encointer-client-notee', help='the client to communicate with the chain')
+@click.option('--port', default='9944', help='port for the client to communicate with chain')
+@click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used')
+def main(ipfs_local, client, port):
+    client = Client(rust_client=client, port=port)
     spec_file_path = f'{TEST_DATA_DIR}{SPEC_FILE}'
 
     cid = client.new_community(spec_file_path, account1)
@@ -117,11 +121,4 @@ def main(ipfs_local, client=Client()):
 
 
 if __name__ == '__main__':
-    p = argparse.ArgumentParser(prog='bootstrap-demo-community', parents=[simple_parser()])
-    p.add_argument('--ipfs-local', '-l', action='store_true', help="set this option to use the local ipfs daemon")
-
-    args = p.parse_args()
-
-    print(f"Starting script with client '{args.client}' on port {args.port}")
-
-    main(args.ipfs_local, Client(rust_client=args.client, port=args.port))
+    main()

--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -56,7 +56,7 @@ def update_spec_with_cid(file, cid):
 @click.command()
 @click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
-@click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used')
+@click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used.')
 def main(ipfs_local, client, port):
     client = Client(rust_client=client, port=port)
     spec_file_path = f'{TEST_DATA_DIR}{SPEC_FILE}'

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -25,7 +25,7 @@ import geojson
 from random_words import RandomWords
 from math import floor
 
-from py_client.helpers import purge_prompt, read_cid, write_cid, zip_folder
+from py_client.helpers import purge_prompt, read_cid, write_cid, zip_folder, set_local_or_remote_chain
 from py_client.client import Client, ExtrinsicFeePaymentImpossible, ExtrinsicWrongPhase, UnknownError, ParticipantAlreadyLinked
 from py_client.ipfs import Ipfs, ICONS_PATH
 from py_client.communities import populate_locations, generate_community_spec, meta_json
@@ -40,7 +40,6 @@ MAX_POPULATION = 12 * NUMBER_OF_LOCATIONS
 @click.pass_context
 def cli(ctx, client):
     ctx.obj = client
-    pass
 
 
 @cli.command()
@@ -132,14 +131,6 @@ def init_bootstrappers(client: Client):
 
 def purge_keystore_prompt():
     purge_prompt(KEYSTORE_PATH, 'accounts')
-
-
-def set_local_or_remote_chain(client: str, port: str, node_url: str):
-    if (node_url == None):
-        client = Client(rust_client=client, port=port)
-    else:
-        client = Client(rust_client=client, node_url='wss://gesell.encointer.org', port=443)
-    return client
 
 
 def register_participants(client: Client, accounts, cid):

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -36,8 +36,8 @@ MAX_POPULATION = 12 * NUMBER_OF_LOCATIONS
 
 
 @click.group()
-@click.option('--client', default='../target/release/encointer-client-notee', help='the client to communicate with the chain')
-@click.option('--port', default='9944', help='port for the client to communicate with chain')
+@click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
+@click.option('--port', default='9944', help='ws-port of the chain.')
 @click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used')
 @click.option('--node_url', default=None, help='if set, remote chain is used with port 443, no need to manually set port, it will be ignored')
 @click.pass_context
@@ -74,10 +74,10 @@ def init(ctx):
 @cli.command()
 @click.pass_obj
 def run(ctx):
-    return run_no_annotators(ctx['client'])
+    return execute_current_phase(ctx['client'])
 
 
-def run_no_annotators(client: Client):
+def execute_current_phase(client: Client):
     client = client
     cid = read_cid()
     phase = client.get_phase()
@@ -106,7 +106,7 @@ def benchmark(ctx):
     py_client = ctx['client']
     print('will grow population forever')
     while True:
-        phase = run_no_annotators(py_client)
+        phase = execute_current_phase(py_client)
         while phase == py_client.get_phase():
             py_client.await_block()
 

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -73,11 +73,11 @@ def init(ctx):
 
 @cli.command()
 @click.pass_obj
-def run(ctx):
-    return run_without_annotators(ctx['client'])
+def execute_current_phase(ctx):
+    return _execute_current_phase(ctx['client'])
 
 
-def run_without_annotators(client: Client):
+def _execute_current_phase(client: Client):
     client = client
     cid = read_cid()
     phase = client.get_phase()
@@ -106,7 +106,7 @@ def benchmark(ctx):
     py_client = ctx['client']
     print('will grow population forever')
     while True:
-        phase = run_without_annotators(py_client)
+        phase = _execute_current_phase(py_client)
         while phase == py_client.get_phase():
             py_client.await_block()
 

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -38,8 +38,8 @@ MAX_POPULATION = 12 * NUMBER_OF_LOCATIONS
 @click.group()
 @click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
-@click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used')
-@click.option('-r', '--remote_chain', default=None, help='choose one of the remote chains: gesell, gesell-dot, gesell-ksm, cantillon-dot, cantillon-ksm')
+@click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used.')
+@click.option('-r', '--remote_chain', default=None, help='choose one of the remote chains: gesell.')
 @click.pass_context
 def cli(ctx, client, port, ipfs_local, remote_chain):
     ctx.ensure_object(dict)
@@ -74,10 +74,10 @@ def init(ctx):
 @cli.command()
 @click.pass_obj
 def run(ctx):
-    return execute_current_phase(ctx['client'])
+    return run_without_annotators(ctx['client'])
 
 
-def execute_current_phase(client: Client):
+def run_without_annotators(client: Client):
     client = client
     cid = read_cid()
     phase = client.get_phase()
@@ -106,7 +106,7 @@ def benchmark(ctx):
     py_client = ctx['client']
     print('will grow population forever')
     while True:
-        phase = execute_current_phase(py_client)
+        phase = run_without_annotators(py_client)
         while phase == py_client.get_phase():
             py_client.await_block()
 

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -21,6 +21,7 @@ import argparse
 import glob
 import os
 
+import click
 import geojson
 
 from random_words import RandomWords
@@ -35,6 +36,102 @@ from py_client.communities import populate_locations, generate_community_spec, m
 KEYSTORE_PATH = './my_keystore'
 NUMBER_OF_LOCATIONS = 100
 MAX_POPULATION = 12 * NUMBER_OF_LOCATIONS
+
+
+@click.group()
+@click.pass_context
+def cli(ctx):
+    ctx.obj['client'] = Client()
+
+
+@cli.command()
+@click.option('--port', default='9944', help='port for the client to communicate with node')
+@click.option('-l', '--ipfs_local', is_flag=True, help='ipfs local node or remote')
+@click.option('--node_url', default=None, help='if set, remote gesell node is used with port 443')
+@click.pass_context
+def init2(ctx, port: str, ipfs_local: bool, node_url: str):
+    client_cli = ctx.obj['client'].cli[0]
+    client = setLocalOrRemoteChain(client_cli, port, node_url)
+    purge_keystore_prompt()
+
+    root_dir = os.path.realpath(ICONS_PATH)
+    zipped_folder = zip_folder("icons", root_dir)
+    try:
+        ipfs_cid = Ipfs.add(zipped_folder, ipfs_local)
+    except:
+        print("add image to ipfs failed")
+    print('initializing community')
+    b = init_bootstrappers(client)
+    specfile = random_community_spec(b, ipfs_cid)
+    print(f'generated community spec: {specfile} first bootstrapper {b[0]}')
+    cid = client.new_community(specfile, b[0])
+    print(f'created community with cid: {cid}')
+    write_cid(cid)
+
+
+@cli.command()
+@click.option('--port', default='9944', help='port for the client to communicate with node')
+@click.option('--node_url', default=None, help='if set, remote gesell node is used with port 443')
+@click.option('--cid',
+              default='41eSfKJrhrR6CYxPfUbwAN18R77WbxXoViRWQMAF4hJB',
+              help='community identifier base58 encoded. Default is Mediterranean test currency')
+@click.pass_context
+def run2(client: str, port: int, node_url: str):
+    client = setLocalOrRemoteChain(client,port,node_url)
+    cid = read_cid()
+    phase = client.get_phase()
+    print(f'phase is {phase}')
+    accounts = client.list_accounts()
+    print(f'number of known accounts: {len(accounts)}')
+    if phase == 'REGISTERING':
+        register_participants(client, accounts, cid)
+        client.await_block()
+    if phase == "ASSIGNING":
+        meetups = client.list_meetups(cid);
+        meetup_sizes = list(map(lambda x: len(x), meetups))
+        print(f'meetups assigned for {sum(meetup_sizes)} participants with sizes: {meetup_sizes}')
+    if phase == 'ATTESTING':
+        meetups = client.list_meetups(cid)
+        print(f'****** Performing {len(meetups)} meetups')
+        for meetup in meetups:
+            perform_meetup(client, meetup, cid)
+        client.await_block()
+    return phase
+
+
+@cli.command()
+@click.option('--port', default='9944', help='port for the client to communicate with node')
+@click.option('--node_url', default=None, help='if set, remote gesell node is used with port 443')
+@click.option('--cid',
+              default='41eSfKJrhrR6CYxPfUbwAN18R77WbxXoViRWQMAF4hJB',
+              help='community identifier base58 encoded. Default is Mediterranean test currency')
+@click.pass_context
+def benchmark2(client: str, port: str, node_url: str):
+    py_client = setLocalOrRemoteChain(client,port,node_url)
+    print('will grow population forever')
+    while True:
+        phase = run(client, port, node_url)
+        while phase == py_client.get_phase():
+            py_client.await_block()
+
+
+def init(client: str, port: str, ipfs_local: str, node_url: str):
+    client = setLocalOrRemoteChain(client, port, node_url)
+    purge_keystore_prompt()
+
+    root_dir = os.path.realpath(ICONS_PATH)
+    zipped_folder = zip_folder("icons", root_dir)
+    try:
+        ipfs_cid = Ipfs.add(zipped_folder, ipfs_local)
+    except:
+        print("add image to ipfs failed")
+    print('initializing community')
+    b = init_bootstrappers(client)
+    specfile = random_community_spec(b, ipfs_cid)
+    print(f'generated community spec: {specfile} first bootstrapper {b[0]}')
+    cid = client.new_community(specfile, b[0])
+    print(f'created community with cid: {cid}')
+    write_cid(cid)
 
 def random_community_spec(bootstrappers, ipfs_cid):
     point = geojson.utils.generate_random("Point", boundingBox=[-56, 41, -21, 13])
@@ -58,25 +155,6 @@ def init_bootstrappers(client: Client):
 
 def purge_keystore_prompt():
     purge_prompt(KEYSTORE_PATH, 'accounts')
-
-
-def init(client: str, port: str, ipfs_local: str, node_url: str):
-    client = setLocalOrRemoteChain(client, port, node_url)
-    purge_keystore_prompt()
-
-    root_dir = os.path.realpath(ICONS_PATH)
-    zipped_folder = zip_folder("icons",root_dir)
-    try:
-        ipfs_cid = Ipfs.add(zipped_folder, ipfs_local)
-    except:
-        print("add image to ipfs failed")
-    print('initializing community')
-    b = init_bootstrappers(client)
-    specfile = random_community_spec(b, ipfs_cid)
-    print(f'generated community spec: {specfile} first bootstrapper {b[0]}')
-    cid = client.new_community(specfile, b[0])
-    print(f'created community with cid: {cid}')
-    write_cid(cid)
 
 
 def setLocalOrRemoteChain(client: str, port: str, node_url: str):
@@ -164,16 +242,17 @@ def benchmark(client: str, port: str, node_url: str):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(prog='bot-community', parents=[simple_parser()])
-    subparsers = parser.add_subparsers(dest='subparser', help='sub-command help')
-    # Note: the function args' names `client` and `port` must match the cli's args' names.
-    # Otherwise, the the values can't be extracted from the `**kwargs`.
-    parser_a = subparsers.add_parser('init', help='a help')
-    parser_a.add_argument('--ipfs-local', '-l', action='store_true', help="set this option to use the local ipfs daemon")
-    parser_b = subparsers.add_parser('run', help='b help')
-    parser_c = subparsers.add_parser('benchmark', help='b help')
-    kwargs = vars(parser.parse_args())
-    try:
-        globals()[kwargs.pop('subparser')](**kwargs)
-    except KeyError:
-        parser.print_help()
+    cli(obj={})
+    # parser = argparse.ArgumentParser(prog='bot-community', parents=[simple_parser()])
+    # subparsers = parser.add_subparsers(dest='subparser', help='sub-command help')
+    # # Note: the function args' names `client` and `port` must match the cli's args' names.
+    # # Otherwise, the the values can't be extracted from the `**kwargs`.
+    # parser_a = subparsers.add_parser('init', help='a help')
+    # parser_a.add_argument('--ipfs-local', '-l', action='store_true', help="set this option to use the local ipfs daemon")
+    # parser_b = subparsers.add_parser('run', help='b help')
+    # parser_c = subparsers.add_parser('benchmark', help='b help')
+    # kwargs = vars(parser.parse_args())
+    # try:
+    #     globals()[kwargs.pop('subparser')](**kwargs)
+    # except KeyError:
+    #     parser.print_help()

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -99,6 +99,7 @@ def run_no_annotators(client: Client):
         client.await_block()
     return phase
 
+
 @cli.command()
 @click.pass_obj
 def benchmark(ctx):

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -39,15 +39,15 @@ MAX_POPULATION = 12 * NUMBER_OF_LOCATIONS
 @click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
 @click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used')
-@click.option('--node_url', default=None, help='if set, remote chain is used with port 443, no need to manually set port, it will be ignored')
+@click.option('-r', '--remote_chain', default=None, help='choose one of the remote chains: gesell, gesell-dot, gesell-ksm, cantillon-dot, cantillon-ksm')
 @click.pass_context
-def cli(ctx, client, port, ipfs_local, node_url):
+def cli(ctx, client, port, ipfs_local, remote_chain):
     ctx.ensure_object(dict)
-    cl = set_local_or_remote_chain(client, port, node_url)
+    cl = set_local_or_remote_chain(client, port, remote_chain)
     ctx.obj['client'] = cl
     ctx.obj['port'] = port
     ctx.obj['ipfs_local'] = ipfs_local
-    ctx.obj['node_url'] = node_url
+    ctx.obj['remote_chain'] = remote_chain
 
 
 @cli.command()

--- a/client/phase.py
+++ b/client/phase.py
@@ -12,27 +12,24 @@ import click
 import substrateinterface
 import json
 from py_client.client import Client
+from py_client.helpers import set_local_or_remote_chain
 
 global COUNT
 COUNT = 0
 
 
 @click.command()
-@click.option('--node_url', default=None, help='if set, remote chain is used with port 443, no need to manually set port, it will be ignored')
+@click.option('-r', '--remote_chain', default=None, help='choose one of the remote chains: gesell, gesell-dot, gesell-ksm, cantillon-dot, cantillon-ksm')
 @click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
-def main(node_url, client, port):
+def main(remote_chain, client, port):
     localhost = None
-    if node_url is None:
-        client = Client(rust_client=client, port=port)
-        localhost = "ws://127.0.0.1"
-    else:
-        client = Client(rust_client=client, node_url='wss://gesell.encointer.org', port=443)
+    client = set_local_or_remote_chain(client, port, remote_chain)
     global COUNT
     with open('typedefs.json') as f:
         custom_type_registry = json.load(f)
     substrate = substrateinterface.SubstrateInterface(
-        url=  f"ws://127.0.0.1:{port}" if localhost is not None else f"{node_url}:{443}",
+        url=  f"ws://127.0.0.1:{port}" if localhost is not None else f"{remote_chain}:{443}",
         ss58_format=42,
         type_registry_preset='substrate-node-template',
         type_registry=custom_type_registry

--- a/client/phase.py
+++ b/client/phase.py
@@ -8,13 +8,10 @@ useful for benchmarking bot communities in a local setup
 """
 
 import subprocess
-import argparse
+import click
 import substrateinterface
 import json
 from py_client.client import Client
-from py_client.arg_parser import simple_parser
-
-global COUNT
 
 
 def subscription_handler(event_count, update_nr, subscription_id):
@@ -34,16 +31,16 @@ if __name__ == '__main__':
     args = p.parse_args()
     # print(f"Starting script with client '{args.client}' on port {args.port}")
     localhost = None
-    if(args.node_url == None):
-        client = Client(rust_client=args.client, port=args.port)
+    if node_url is None:
+        client = Client(rust_client=client, port=port)
         localhost = "ws://127.0.0.1"
     else:
-        client = Client(rust_client=args.client, node_url='wss://gesell.encointer.org', port=443)
-    COUNT = 0
+        client = Client(rust_client=client, node_url='wss://gesell.encointer.org', port=443)
+    global COUNT
     with open('typedefs.json') as f:
         custom_type_registry = json.load(f)
     substrate = substrateinterface.SubstrateInterface(
-        url=  f"ws://127.0.0.1:{args.port}" if localhost != None else f"{args.node_url}:{443}",
+        url=  f"ws://127.0.0.1:{port}" if localhost is not None else f"{node_url}:{443}",
         ss58_format=42,
         type_registry_preset='substrate-node-template',
         type_registry=custom_type_registry
@@ -53,3 +50,18 @@ if __name__ == '__main__':
         print('NEXT PHASE!')
         client.next_phase()
         COUNT = 0
+
+
+def subscription_handler(event_count, update_nr, subscription_id):
+    global COUNT
+    print(f'events: {event_count}, idle blocks {COUNT}')
+    if COUNT > 10:
+        return update_nr
+    elif event_count.value == 1:
+        COUNT += 1
+    else:
+        COUNT = 0
+
+
+if __name__ == '__main__':
+    main()

--- a/client/phase.py
+++ b/client/phase.py
@@ -13,23 +13,15 @@ import substrateinterface
 import json
 from py_client.client import Client
 
-
-def subscription_handler(event_count, update_nr, subscription_id):
-    global COUNT
-    print(f'events: {event_count}, idle blocks {COUNT}')
-    if COUNT > 10:
-        return update_nr
-    elif event_count.value == 1:
-        COUNT += 1
-    else:
-        COUNT = 0
+global COUNT
+COUNT = 0
 
 
-if __name__ == '__main__':
-    p = argparse.ArgumentParser(
-    prog='register-businesses', parents=[simple_parser()])
-    args = p.parse_args()
-    # print(f"Starting script with client '{args.client}' on port {args.port}")
+@click.command()
+@click.option('--node_url', default=None, help='if set, remote chain is used with port 443, no need to manually set port, it will be ignored')
+@click.option('--client', default='../target/release/encointer-client-notee', help='the client to communicate with the chain')
+@click.option('--port', default='9944', help='port for the client to communicate with chain')
+def main(node_url, client, port):
     localhost = None
     if node_url is None:
         client = Client(rust_client=client, port=port)

--- a/client/phase.py
+++ b/client/phase.py
@@ -19,8 +19,8 @@ COUNT = 0
 
 @click.command()
 @click.option('--node_url', default=None, help='if set, remote chain is used with port 443, no need to manually set port, it will be ignored')
-@click.option('--client', default='../target/release/encointer-client-notee', help='the client to communicate with the chain')
-@click.option('--port', default='9944', help='port for the client to communicate with chain')
+@click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
+@click.option('--port', default='9944', help='ws-port of the chain.')
 def main(node_url, client, port):
     localhost = None
     if node_url is None:

--- a/client/phase.py
+++ b/client/phase.py
@@ -19,7 +19,7 @@ COUNT = 0
 
 
 @click.command()
-@click.option('-r', '--remote_chain', default=None, help='choose one of the remote chains: gesell, gesell-dot, gesell-ksm, cantillon-dot, cantillon-ksm')
+@click.option('-r', '--remote_chain', default=None, help='choose one of the remote chains: gesell.')
 @click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
 def main(remote_chain, client, port):
@@ -29,7 +29,7 @@ def main(remote_chain, client, port):
     with open('typedefs.json') as f:
         custom_type_registry = json.load(f)
     substrate = substrateinterface.SubstrateInterface(
-        url=  f"ws://127.0.0.1:{port}" if localhost is not None else f"{remote_chain}:{443}",
+        url= f"wss://gesell.encointer.org:{443}" if localhost is not None else f"ws://127.0.0.1:{port}",
         ss58_format=42,
         type_registry_preset='substrate-node-template',
         type_registry=custom_type_registry

--- a/client/py_client/helpers.py
+++ b/client/py_client/helpers.py
@@ -58,7 +58,7 @@ def take_only_last_cid(ret_cids):
 
 
 def set_local_or_remote_chain(client: str, port: str, node_url: str):
-    if (node_url == None):
+    if node_url is None:
         client = Client(rust_client=client, port=port)
     else:
         client = Client(rust_client=client, node_url='wss://gesell.encointer.org', port=443)

--- a/client/py_client/helpers.py
+++ b/client/py_client/helpers.py
@@ -61,5 +61,8 @@ def set_local_or_remote_chain(client: str, port: str, node_url: str):
     if node_url is None:
         client = Client(rust_client=client, port=port)
     else:
-        client = Client(rust_client=client, node_url='wss://gesell.encointer.org', port=443)
+        if node_url == "gesell":
+            client = Client(rust_client=client, node_url='wss://gesell.encointer.org', port=443)
+        else:
+            raise Exception("You need to choose a valid remote chain")
     return client

--- a/client/py_client/helpers.py
+++ b/client/py_client/helpers.py
@@ -5,6 +5,8 @@ import re
 import shutil
 from os import path
 
+from .client import Client
+
 def zip_folder(name: str, folder_abs_path: str):
     return shutil.make_archive(f"{name}","zip", folder_abs_path)
 
@@ -53,3 +55,11 @@ def take_only_last_cid(ret_cids):
             warnings.warn('No cid returned. Something happened. stderr: ')
             warnings.warn(str(ret_cids.stderr))
             return ''
+
+
+def set_local_or_remote_chain(client: str, port: str, node_url: str):
+    if (node_url == None):
+        client = Client(rust_client=client, port=port)
+    else:
+        client = Client(rust_client=client, node_url='wss://gesell.encointer.org', port=443)
+    return client

--- a/client/register-business-simple.py
+++ b/client/register-business-simple.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
-# import argparse
-# from py_client.arg_parser import simple_parser
 
 import json
-import glob
 from py_client.client import Client
 from py_client.ipfs import Ipfs
 from py_client.helpers import read_cid

--- a/client/register-businesses.py
+++ b/client/register-businesses.py
@@ -83,7 +83,7 @@ def create_businesses(amount: int):
     mkdir_p(BUSINESSES_PATH)
 
     for i in range(amount):
-        b = random_business(IPFS_LOCAL)
+        b = random_business()
         f_name = f'{BUSINESSES_PATH}/{b["name"]}_{i}.json'
         print(f'Dumping business {b} to {f_name}')
         with open(f_name, 'w') as outfile:
@@ -102,7 +102,7 @@ def create_offerings(community_identifier: str, amount: int):
     mkdir_p(OFFERINGS_PATH)
 
     for i in range(amount):
-        o = random_offering(community_identifier, IPFS_LOCAL)
+        o = random_offering(community_identifier)
         f_name = f'{OFFERINGS_PATH}/{o["name"]}_{i}.json'
         print(f'Dumping offerings {o} to {f_name}')
         with open(f_name, 'w') as outfile:

--- a/client/register-businesses.py
+++ b/client/register-businesses.py
@@ -3,7 +3,9 @@ import argparse
 import glob
 import json
 import random
-import os 
+import os
+
+import click
 
 from random_words import RandomWords
 from wonderwords import RandomSentence
@@ -11,113 +13,39 @@ from wonderwords import RandomSentence
 from py_client.arg_parser import simple_parser
 from py_client.client import Client
 from py_client.ipfs import Ipfs
-from py_client.helpers import purge_prompt, read_cid, mkdir_p
+from py_client.helpers import purge_prompt, read_cid, mkdir_p, set_local_or_remote_chain
 
 BUSINESSES_PATH = './test-data/bazaar/businesses'
 OFFERINGS_PATH = './test-data/bazaar/offerings'
 
 ICON_PATH = './test-data/icons/community_icon.png'
 
-def create_businesses(amount: int):
-    """
-    Create some businesses and dump them to the test-data dir.
+@click.group()
+@click.option('--client', default='../target/release/encointer-client-notee', help='the client to communicate with the chain')
+@click.option('--port', default='9944', help='port for the client to communicate with chain')
+@click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used')
+@click.option('--node_url', default=None, help='if set, remote chain is used with port 443, no need to manually set port, it will be ignored')
+@click.pass_context
+def cli(ctx, client, port, ipfs_local, node_url):
+    ctx.ensure_object(dict)
+    cl = set_local_or_remote_chain(client, port, node_url)
+    ctx.obj['client'] = cl
+    ctx.obj['port'] = port
+    ctx.obj['ipfs_local'] = ipfs_local
+    ctx.obj['node_url'] = node_url
 
-    :param amount:
-    :return:
-    """
-    purge_prompt(BUSINESSES_PATH, 'businesses')
-    mkdir_p(BUSINESSES_PATH)
-
-    for i in range(amount):
-        b = random_business()
-        f_name = f'{BUSINESSES_PATH}/{b["name"]}_{i}.json'
-        print(f'Dumping business {b} to {f_name}')
-        with open(f_name, 'w') as outfile:
-            json.dump(b, outfile, indent=2)
-
-
-def create_offerings(community_identifier: str, amount: int):
-    """
-    Create some offerings and dump them to the test-data dir.
-
-    :param community_identifier:
-    :param amount:
-    :return:
-    """
-    purge_prompt(OFFERINGS_PATH, 'offerings')
-    mkdir_p(OFFERINGS_PATH)
-
-    for i in range(amount):
-        o = random_offering(community_identifier)
-        f_name = f'{OFFERINGS_PATH}/{o["name"]}_{i}.json'
-        print(f'Dumping offerings {o} to {f_name}')
-        with open(f_name, 'w') as outfile:
-            json.dump(o, outfile, indent=2)
-
-
-def random_business():
-    """
-        Create a random business.
-
-    Note:   This `Business` format is not definite, but it does not matter for simple testing as we upload only
-            the ipfs_cid.
-            Later, the Icon should be a user specified one, this is just for testing
-    :return:
-    """
-    print("adding business image to remote: ")
-    image_cid = Ipfs.add(ICON_PATH, args.ipfs_local)
-    s = RandomSentence()
-    return {
-        "name": RandomWords().random_words(count=1)[0],
-        "description": s.sentence(),
-        "image_cid": image_cid
-    }
-
-
-def random_offering(community_identifier):
-    """
-    Create a random offering.
-
-    Note:   This `Offering` format is not definite, but it does not matter for simple testing as we upload only
-            the ipfs_cid.
-    :param community_identifier:
-    :return:
-    """
-    print("adding offering image to remote: ")
-    image_cid = Ipfs.add(ICON_PATH, args.ipfs_local)
-    return {
-        "name": RandomWords().random_words(count=1)[0],
-        "price": random.randint(0, 100),
-        "community": community_identifier,
-        "image_cid": image_cid
-    }
-
-
-def shop_owners():
-    """
-        Note: Only `//Alice` and `//Bob` have funds. Other accounts need to fauceted as in the other scripts.
-    """
-    return ['//Alice', '//Bob']
-
-
-if __name__ == '__main__':
-    p = argparse.ArgumentParser(
-    prog='register-businesses', parents=[simple_parser()])
-    p.add_argument('--ipfs-local', '-l', action='store_true', help="set this option to use the local ipfs daemon")
-    args = p.parse_args()
-    # print(f"Starting script with client '{args.client}' on port {args.port}")
-    if(args.node_url == None):
-        client = Client(rust_client=args.client, port=args.port)
-    else:
-        client = Client(rust_client=args.client, node_url='wss://gesell.encointer.org', port=443)
+@cli.command()
+@click.pass_obj
+def register(ctx):
+    client = ctx['client']
     owners = shop_owners()
 
     # As we try to read to the cid here, we must have called `./bootstrap_demo_community.py init` before calling this
     # script
     cid = read_cid()
 
-    create_businesses(2)
-    business_ipfs_cids = Ipfs.add_multiple(glob.glob(BUSINESSES_PATH + '/*.json'),args.ipfs_local)
+    create_businesses(2, ctx['ipfs_local'])
+    business_ipfs_cids = Ipfs.add_multiple(glob.glob(BUSINESSES_PATH + '/*.json'), ctx['ipfs_local'])
     print(f'Uploaded businesses to ipfs: ipfs_cids: {business_ipfs_cids}')
 
     for bi in range(len(business_ipfs_cids)):
@@ -132,9 +60,9 @@ if __name__ == '__main__':
         print(client.create_business(owner, cid, c))
         client.await_block()
 
-    create_offerings(cid, 5)
+    create_offerings(cid, 5, ctx['ipfs_local'])
 
-    offerings_ipfs_cids = Ipfs.add_multiple(glob.glob(OFFERINGS_PATH + '/*.json'), args.ipfs_local)
+    offerings_ipfs_cids = Ipfs.add_multiple(glob.glob(OFFERINGS_PATH + '/*.json'), ctx['ipfs_local'])
     print(f'Uploaded offerings to ipfs: ipfs_cids: {offerings_ipfs_cids}')
 
     for c in offerings_ipfs_cids:
@@ -153,3 +81,88 @@ if __name__ == '__main__':
     print(client.list_businesses(cid))
     print(client.list_offerings(cid))
     print(client.list_offerings_for_business(cid, owners[0]))
+
+def create_businesses(amount: int, ipfs_local):
+    """
+    Create some businesses and dump them to the test-data dir.
+
+    :param amount:
+    :return:
+    """
+    purge_prompt(BUSINESSES_PATH, 'businesses')
+    mkdir_p(BUSINESSES_PATH)
+
+    for i in range(amount):
+        b = random_business(ipfs_local)
+        f_name = f'{BUSINESSES_PATH}/{b["name"]}_{i}.json'
+        print(f'Dumping business {b} to {f_name}')
+        with open(f_name, 'w') as outfile:
+            json.dump(b, outfile, indent=2)
+
+
+def create_offerings(community_identifier: str, amount: int, ipfs_local):
+    """
+    Create some offerings and dump them to the test-data dir.
+
+    :param community_identifier:
+    :param amount:
+    :return:
+    """
+    purge_prompt(OFFERINGS_PATH, 'offerings')
+    mkdir_p(OFFERINGS_PATH)
+
+    for i in range(amount):
+        o = random_offering(community_identifier, ipfs_local)
+        f_name = f'{OFFERINGS_PATH}/{o["name"]}_{i}.json'
+        print(f'Dumping offerings {o} to {f_name}')
+        with open(f_name, 'w') as outfile:
+            json.dump(o, outfile, indent=2)
+
+
+def random_business(ipfs_local):
+    """
+        Create a random business.
+
+    Note:   This `Business` format is not definite, but it does not matter for simple testing as we upload only
+            the ipfs_cid.
+            Later, the Icon should be a user specified one, this is just for testing
+    :return:
+    """
+    print("adding business image to remote: ")
+    image_cid = Ipfs.add(ICON_PATH, ipfs_local)
+    s = RandomSentence()
+    return {
+        "name": RandomWords().random_words(count=1)[0],
+        "description": s.sentence(),
+        "image_cid": image_cid
+    }
+
+
+def random_offering(community_identifier, ipfs_local):
+    """
+    Create a random offering.
+
+    Note:   This `Offering` format is not definite, but it does not matter for simple testing as we upload only
+            the ipfs_cid.
+    :param community_identifier:
+    :return:
+    """
+    print("adding offering image to remote: ")
+    image_cid = Ipfs.add(ICON_PATH, ipfs_local)
+    return {
+        "name": RandomWords().random_words(count=1)[0],
+        "price": random.randint(0, 100),
+        "community": community_identifier,
+        "image_cid": image_cid
+    }
+
+
+def shop_owners():
+    """
+        Note: Only `//Alice` and `//Bob` have funds. Other accounts need to fauceted as in the other scripts.
+    """
+    return ['//Alice', '//Bob']
+
+
+if __name__ == '__main__':
+    cli(obj={})

--- a/client/register-businesses.py
+++ b/client/register-businesses.py
@@ -21,10 +21,10 @@ global IPFS_LOCAL
 @click.command()
 @click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
-@click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used')
-@click.option('--node_url', default=None, help='if set, remote chain is used with port 443, no need to manually set port, it will be ignored')
-def register(client, port, ipfs_local, node_url):
-    client = set_local_or_remote_chain(client, port, node_url)
+@click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used.')
+@click.option('-r', '--remote_chain', default=None, help='choose one of the remote chains: gesell, gesell-dot, gesell-ksm, cantillon-dot, cantillon-ksm.')
+def register(client, port, ipfs_local, remote_chain):
+    client = set_local_or_remote_chain(client, port, remote_chain)
     global IPFS_LOCAL
     IPFS_LOCAL = ipfs_local
     owners = shop_owners()

--- a/client/register-businesses.py
+++ b/client/register-businesses.py
@@ -119,7 +119,6 @@ def random_business():
     :return:
     """
     print("adding business image to remote: ")
-    print(f"IPFS IS: {IPFS_LOCAL}")
     image_cid = Ipfs.add(ICON_PATH, IPFS_LOCAL)
     s = RandomSentence()
     return {

--- a/client/register-businesses.py
+++ b/client/register-businesses.py
@@ -16,32 +16,22 @@ OFFERINGS_PATH = './test-data/bazaar/offerings'
 
 ICON_PATH = './test-data/icons/community_icon.png'
 
-@click.group()
+
+@click.command()
 @click.option('--client', default='../target/release/encointer-client-notee', help='the client to communicate with the chain')
 @click.option('--port', default='9944', help='port for the client to communicate with chain')
 @click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used')
 @click.option('--node_url', default=None, help='if set, remote chain is used with port 443, no need to manually set port, it will be ignored')
-@click.pass_context
-def cli(ctx, client, port, ipfs_local, node_url):
-    ctx.ensure_object(dict)
-    cl = set_local_or_remote_chain(client, port, node_url)
-    ctx.obj['client'] = cl
-    ctx.obj['port'] = port
-    ctx.obj['ipfs_local'] = ipfs_local
-    ctx.obj['node_url'] = node_url
-
-@cli.command()
-@click.pass_obj
-def register(ctx):
-    client = ctx['client']
+def register(client, port, ipfs_local, node_url):
+    client = set_local_or_remote_chain(client, port, node_url)
     owners = shop_owners()
 
     # As we try to read to the cid here, we must have called `./bootstrap_demo_community.py init` before calling this
     # script
     cid = read_cid()
 
-    create_businesses(2, ctx['ipfs_local'])
-    business_ipfs_cids = Ipfs.add_multiple(glob.glob(BUSINESSES_PATH + '/*.json'), ctx['ipfs_local'])
+    create_businesses(2, ipfs_local)
+    business_ipfs_cids = Ipfs.add_multiple(glob.glob(BUSINESSES_PATH + '/*.json'), ipfs_local)
     print(f'Uploaded businesses to ipfs: ipfs_cids: {business_ipfs_cids}')
 
     for bi in range(len(business_ipfs_cids)):
@@ -56,9 +46,9 @@ def register(ctx):
         print(client.create_business(owner, cid, c))
         client.await_block()
 
-    create_offerings(cid, 5, ctx['ipfs_local'])
+    create_offerings(cid, 5, ipfs_local)
 
-    offerings_ipfs_cids = Ipfs.add_multiple(glob.glob(OFFERINGS_PATH + '/*.json'), ctx['ipfs_local'])
+    offerings_ipfs_cids = Ipfs.add_multiple(glob.glob(OFFERINGS_PATH + '/*.json'), ipfs_local)
     print(f'Uploaded offerings to ipfs: ipfs_cids: {offerings_ipfs_cids}')
 
     for c in offerings_ipfs_cids:
@@ -161,4 +151,4 @@ def shop_owners():
 
 
 if __name__ == '__main__':
-    cli(obj={})
+    register()

--- a/client/register-businesses.py
+++ b/client/register-businesses.py
@@ -1,17 +1,13 @@
 #!/usr/bin/env python3
-import argparse
 import glob
 import json
 import random
-import os
 
 import click
 
 from random_words import RandomWords
 from wonderwords import RandomSentence
 
-from py_client.arg_parser import simple_parser
-from py_client.client import Client
 from py_client.ipfs import Ipfs
 from py_client.helpers import purge_prompt, read_cid, mkdir_p, set_local_or_remote_chain
 

--- a/client/register-businesses.py
+++ b/client/register-businesses.py
@@ -19,8 +19,8 @@ ICON_PATH = './test-data/icons/community_icon.png'
 global IPFS_LOCAL
 
 @click.command()
-@click.option('--client', default='../target/release/encointer-client-notee', help='the client to communicate with the chain')
-@click.option('--port', default='9944', help='port for the client to communicate with chain')
+@click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
+@click.option('--port', default='9944', help='ws-port of the chain.')
 @click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used')
 @click.option('--node_url', default=None, help='if set, remote chain is used with port 443, no need to manually set port, it will be ignored')
 def register(client, port, ipfs_local, node_url):

--- a/client/register-businesses.py
+++ b/client/register-businesses.py
@@ -22,8 +22,8 @@ global IPFS_LOCAL
 @click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
 @click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used.')
-@click.option('-r', '--remote_chain', default=None, help='choose one of the remote chains: gesell, gesell-dot, gesell-ksm, cantillon-dot, cantillon-ksm.')
-def register(client, port, ipfs_local, remote_chain):
+@click.option('-r', '--remote_chain', default=None, help='choose one of the remote chains: gesell.')
+def register_businesses_and_offerings(client, port, ipfs_local, remote_chain):
     client = set_local_or_remote_chain(client, port, remote_chain)
     global IPFS_LOCAL
     IPFS_LOCAL = ipfs_local
@@ -119,6 +119,7 @@ def random_business():
     :return:
     """
     print("adding business image to remote: ")
+    print(f"IPFS IS: {IPFS_LOCAL}")
     image_cid = Ipfs.add(ICON_PATH, IPFS_LOCAL)
     s = RandomSentence()
     return {
@@ -155,4 +156,4 @@ def shop_owners():
 
 
 if __name__ == '__main__':
-    register()
+    register_businesses_and_offerings()


### PR DESCRIPTION
click framework is used instead of argparser
closes #133
Remarks: 
- for remote node, the url is hardcoded and the port also fixed. This is because I assume if we connect to remote we use tcp port 443 and wss://gesell.encointer.org. 
If you want I can make that generic, too. I just assumed that if remote people would choose this one in anycase.
- bootsrap_demo_community.py (on gesell 0.7.0): 
1st time excecutes correctly
2nd time throws an error:
ERROR encointer_client_notee] ExtrinsicFailed: Other("") DispatchInfo { weight: 10000, class: DispatchClass::Normal, pays_fee: Pays::Yes }
[2021-11-26T17:37:42Z ERROR encointer_client_notee] ExtrinsicFailed: Module { index: 10, error: 4, message: None } DispatchInfo { weight: 10000, class: DispatchClass::Normal, pays_fee: Pays::Yes }
this also happens on master branch. with 0.6.0 i didnt have error, so apparently breaks with 0.7.0 
- connection to remote node not possible ATM: faucet listens to localhost:5000/api. is there also a remote faucet_url or else i can't create the account on remote node. 
- ~in register-businesses.py: ifps_local had to be added as function argument in multiple function levels to reach the lowest point. This is because now we don't use args (args are global). Maybe I should use a global variable to solve that (other suggestion?)~ solved with global variable