### PR TITLE
v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "encointer-primitives"
 version = "0.7.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f701ef1a91f28a4a9f7daea61533d87c7f87f696"
+source = "git+https://github.com/encointer/pallets?branch=v0.7.0#af56d9533e3a0dc3fff0813d9038fbd2573c7f66"
 dependencies = [
  "bs58",
  "concat-arrays",
@@ -1504,7 +1504,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "substrate-fixed",
 ]
 
 [[package]]
@@ -1541,7 +1540,7 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 [[package]]
 name = "ep-core"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f701ef1a91f28a4a9f7daea61533d87c7f87f696"
+source = "git+https://github.com/encointer/pallets?branch=v0.7.0#af56d9533e3a0dc3fff0813d9038fbd2573c7f66"
 dependencies = [
  "impl-serde",
  "parity-scale-codec 2.3.1",
@@ -1550,6 +1549,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
+ "substrate-fixed",
 ]
 
 [[package]]
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-balances"
 version = "0.7.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f701ef1a91f28a4a9f7daea61533d87c7f87f696"
+source = "git+https://github.com/encointer/pallets?branch=v0.7.0#af56d9533e3a0dc3fff0813d9038fbd2573c7f66"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4207,13 +4207,12 @@ dependencies = [
  "scale-info",
  "sp-runtime",
  "sp-std",
- "substrate-fixed",
 ]
 
 [[package]]
 name = "pallet-encointer-bazaar"
 version = "0.7.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f701ef1a91f28a4a9f7daea61533d87c7f87f696"
+source = "git+https://github.com/encointer/pallets?branch=v0.7.0#af56d9533e3a0dc3fff0813d9038fbd2573c7f66"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4228,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f701ef1a91f28a4a9f7daea61533d87c7f87f696"
+source = "git+https://github.com/encointer/pallets?branch=v0.7.0#af56d9533e3a0dc3fff0813d9038fbd2573c7f66"
 dependencies = [
  "encointer-primitives",
  "jsonrpc-core",
@@ -4247,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f701ef1a91f28a4a9f7daea61533d87c7f87f696"
+source = "git+https://github.com/encointer/pallets?branch=v0.7.0#af56d9533e3a0dc3fff0813d9038fbd2573c7f66"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4258,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies"
 version = "0.7.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f701ef1a91f28a4a9f7daea61533d87c7f87f696"
+source = "git+https://github.com/encointer/pallets?branch=v0.7.0#af56d9533e3a0dc3fff0813d9038fbd2573c7f66"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4277,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities"
 version = "0.7.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f701ef1a91f28a4a9f7daea61533d87c7f87f696"
+source = "git+https://github.com/encointer/pallets?branch=v0.7.0#af56d9533e3a0dc3fff0813d9038fbd2573c7f66"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4291,13 +4290,12 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "substrate-fixed",
 ]
 
 [[package]]
 name = "pallet-encointer-communities-rpc"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f701ef1a91f28a4a9f7daea61533d87c7f87f696"
+source = "git+https://github.com/encointer/pallets?branch=v0.7.0#af56d9533e3a0dc3fff0813d9038fbd2573c7f66"
 dependencies = [
  "encointer-primitives",
  "jsonrpc-core",
@@ -4316,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f701ef1a91f28a4a9f7daea61533d87c7f87f696"
+source = "git+https://github.com/encointer/pallets?branch=v0.7.0#af56d9533e3a0dc3fff0813d9038fbd2573c7f66"
 dependencies = [
  "encointer-primitives",
  "sp-api",
@@ -4326,7 +4324,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-scheduler"
 version = "0.7.0"
-source = "git+https://github.com/encointer/pallets?branch=master#f701ef1a91f28a4a9f7daea61533d87c7f87f696"
+source = "git+https://github.com/encointer/pallets?branch=v0.7.0#af56d9533e3a0dc3fff0813d9038fbd2573c7f66"
 dependencies = [
  "encointer-primitives",
  "frame-support",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -32,31 +32,31 @@ branch = "master"
 [dependencies.encointer-scheduler]
 #default-features = false
 git = "https://github.com/encointer/pallets"
-branch = "master"
+branch = "v0.7.0"
 package = "pallet-encointer-scheduler"
 
 [dependencies.encointer-ceremonies]
 #default-features = false
 git = "https://github.com/encointer/pallets"
-branch = "master"
+branch = "v0.7.0"
 package = "pallet-encointer-ceremonies"
 
 [dependencies.encointer-communities]
 #default-features = false
 git = "https://github.com/encointer/pallets"
-branch = "master"
+branch = "v0.7.0"
 package = "pallet-encointer-communities"
 
 [dependencies.encointer-balances]
 #default-features = false
 git = "https://github.com/encointer/pallets"
-branch = "master"
+branch = "v0.7.0"
 package = "pallet-encointer-balances"
 
 [dependencies.encointer-primitives]
 #default-features = false
 git = "https://github.com/encointer/pallets"
-branch = "master"
+branch = "v0.7.0"
 
 [dependencies.fixed]
 #default-features = false

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1305,10 +1305,8 @@ fn get_community_locations(
 		.get_request(req.into())
 		.unwrap()
 		.expect("Could not find any locations for that cid...");
-	// we only need this mapping because serde can't serialize i128
-	// https://github.com/paritytech/substrate/issues/4641
-	let locations: Vec<[u8; 32]> = serde_json::from_str(&n).unwrap();
-	Some(locations.iter().map(|l| Location::decode(&mut l.as_slice()).unwrap()).collect())
+
+	Some(serde_json::from_str(&n).unwrap())
 }
 
 fn get_meetup_location(

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -59,11 +59,11 @@ frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/pari
 # encointer dependencies
 encointer-node-notee-runtime = { path = "../runtime" }
 
-pallet-encointer-communities-rpc = { git = "https://github.com/encointer/pallets", branch = "master"}
-pallet-encointer-communities-rpc-runtime-api = { git = "https://github.com/encointer/pallets", branch = "master"}
+pallet-encointer-communities-rpc = { git = "https://github.com/encointer/pallets", branch = "v0.7.0"}
+pallet-encointer-communities-rpc-runtime-api = { git = "https://github.com/encointer/pallets", branch = "v0.7.0"}
 
-pallet-encointer-bazaar-rpc = {git = "https://github.com/encointer/pallets", branch = "master"}
-pallet-encointer-bazaar-rpc-runtime-api = {git = "https://github.com/encointer/pallets", branch = "master"}
+pallet-encointer-bazaar-rpc = {git = "https://github.com/encointer/pallets", branch = "v0.7.0"}
+pallet-encointer-bazaar-rpc-runtime-api = {git = "https://github.com/encointer/pallets", branch = "v0.7.0"}
 
 [features]
 default = []

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,49 +12,49 @@ version = "0.7.9"
 [dependencies.encointer-scheduler]
 default-features = false
 git = "https://github.com/encointer/pallets"
-branch = "master"
+branch = "v0.7.0"
 package = "pallet-encointer-scheduler"
 
 [dependencies.encointer-ceremonies]
 default-features = false
 git = "https://github.com/encointer/pallets"
-branch = "master"
+branch = "v0.7.0"
 package = "pallet-encointer-ceremonies"
 
 [dependencies.encointer-communities]
 default-features = false
 git = "https://github.com/encointer/pallets"
-branch = "master"
+branch = "v0.7.0"
 package = "pallet-encointer-communities"
 
 [dependencies.encointer-communities-rpc-runtime-api]
 default-features = false
 git = "https://github.com/encointer/pallets"
-branch = "master"
+branch = "v0.7.0"
 package = "pallet-encointer-communities-rpc-runtime-api"
 
 [dependencies.encointer-balances]
 default-features = false
 git = "https://github.com/encointer/pallets"
-branch = "master"
+branch = "v0.7.0"
 package = "pallet-encointer-balances"
 
 [dependencies.encointer-bazaar]
 default-features = false
 git = "https://github.com/encointer/pallets"
-branch = "master"
+branch = "v0.7.0"
 package = "pallet-encointer-bazaar"
 
 [dependencies.encointer-bazaar-rpc-runtime-api]
 default-features = false
 git = "https://github.com/encointer/pallets"
-branch = "master"
+branch = "v0.7.0"
 package = "pallet-encointer-bazaar-rpc-runtime-api"
 
 [dependencies.encointer-primitives]
 default-features = false
 git = "https://github.com/encointer/pallets"
-branch = "master"
+branch = "v0.7.0"
 
 [dependencies.fixed]
 default-features = false

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -57,8 +57,6 @@ pub use encointer_primitives::{
 	scheduler::CeremonyPhaseType,
 };
 
-use encointer_communities_rpc_runtime_api::LocationSerialized;
-
 /// An index to a block.
 pub type BlockNumber = u32;
 
@@ -594,15 +592,8 @@ impl_runtime_apis! {
 			EncointerCommunities::get_name(cid)
 		}
 
-		fn get_locations(cid: &CommunityIdentifier) -> Vec<LocationSerialized> {
-			let loc = EncointerCommunities::get_locations(cid);
-			// we only need this because serde can't serialize i128
-			// https://github.com/paritytech/substrate/issues/4641
-			loc.iter().map(|l| {
-						let mut ls = LocationSerialized::default();
-						ls.copy_from_slice( &l.encode()[0..32]);
-						ls
-			}).collect()
+		fn get_locations(cid: &CommunityIdentifier) -> Vec<Location> {
+			EncointerCommunities::get_locations(cid)
 		}
 
 	}


### PR DESCRIPTION
This depends on the encointer-pallet's v0.7.0 branch, which contains everything from master except for https://github.com/encointer/pallets/pull/68