### PR TITLE
fix cargo cache error: `assertion failed: sentinel == STR_SENTINEL`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-12-10"
+channel = "nightly-2021-12-15"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy


### PR DESCRIPTION
* Slightly bump the rust toolchain to fix a cargo cache error: https://github.com/rust-lang/rust/issues/91663