### PR TITLE
Add files without folder with ipfs

### DIFF
--- a/client/py_client/ipfs.py
+++ b/client/py_client/ipfs.py
@@ -57,3 +57,22 @@ class Ipfs:
         return [Ipfs.add_recursive(f, local) for f in paths]
 
 
+    @staticmethod
+    def add(path_to_files, local=False):
+        if not (use_ipfs_gateway or local):
+            return "QmWgTp4fBkxyUhnMrx4UVVqQ2McTQKJzq8yq3J5tCzdtfx"
+        if local:
+            ret = subprocess.run(["ipfs", "add", path_to_files], stdout=subprocess.PIPE)
+            return take_only_last_cid(ret)
+        else:
+            ret = subprocess.run(["curl", "-X", "POST", "-F", f"file=@{path_to_files}", "-u", ipfs_api_key, ipfs_add_url], stdout=subprocess.PIPE)
+        return take_only_last_cid(ret)
+
+
+    @staticmethod
+    def add_multiple(paths, local = False):
+        if not (use_ipfs_gateway or local):
+            return ["QmP2fzfikh7VqTu8pvzd2G2vAd4eK7EaazXTEgqGN6AWoD"]
+        return [Ipfs.add(f, local) for f in paths]
+
+

--- a/client/register-businesses.py
+++ b/client/register-businesses.py
@@ -51,7 +51,7 @@ def register_businesses_and_offerings(client, port, ipfs_local, remote_chain):
 
     create_offerings(cid, 5)
 
-    offerings_ipfs_cids = Ipfs.add_multiple_recursive(glob.glob(OFFERINGS_PATH + '/*.json'), ipfs_local)
+    offerings_ipfs_cids = Ipfs.add_multiple(glob.glob(OFFERINGS_PATH + '/*.json'), ipfs_local)
     print(f'Uploaded offerings to ipfs: ipfs_cids: {offerings_ipfs_cids}')
 
     for c in offerings_ipfs_cids:

--- a/client/register-businesses.py
+++ b/client/register-businesses.py
@@ -34,7 +34,7 @@ def register_businesses_and_offerings(client, port, ipfs_local, remote_chain):
     cid = read_cid()
 
     create_businesses(2)
-    business_ipfs_cids = Ipfs.add_multiple_recursive(glob.glob(BUSINESSES_PATH + '/*.json'), ipfs_local)
+    business_ipfs_cids = Ipfs.add_multiple(glob.glob(BUSINESSES_PATH + '/*.json'), ipfs_local)
     print(f'Uploaded businesses to ipfs: ipfs_cids: {business_ipfs_cids}')
 
     for bi in range(len(business_ipfs_cids)):
@@ -119,7 +119,7 @@ def random_business():
     :return:
     """
     print("adding business image to remote: ")
-    image_cid = Ipfs.add_recursive(ICON_PATH, IPFS_LOCAL)
+    image_cid = Ipfs.add(ICON_PATH, IPFS_LOCAL)
     s = RandomSentence()
     return {
         "name": RandomWords().random_words(count=1)[0],
@@ -138,7 +138,7 @@ def random_offering(community_identifier):
     :return:
     """
     print("adding offering image to remote: ")
-    image_cid = Ipfs.add_recursive(ICON_PATH, IPFS_LOCAL)
+    image_cid = Ipfs.add(ICON_PATH, IPFS_LOCAL)
     return {
         "name": RandomWords().random_words(count=1)[0],
         "price": random.randint(0, 100),


### PR DESCRIPTION
i realized, that since we added recursively files to ipfs (including a folder), register businesses didn't work anymore properly.
so i added the functionality of adding single files (businesses/offerings).

I tested it for: 
local chain with 
1. remote ipfs (infura) 
2. local ipfs daemon
Unfortunately, I had a 403 rpc method forbidden error when working with localhost and ubuntu 20.04 (native) 
On windows 11 with wsl 2 it worked without additional configurations (if I didnt also add it long time ago, if it doesn't work, add the same configurations as described below).
I think the problem was related to the ipfs daemon, that wasn't configured and what I think helped me to solve it was:
- closing the ipfs daemon in the terminal.
- adding the following configurations to the daemon (in the terminal):
```
ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[\"*\"]"
ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials "[\"true\"]"
```
3. starting the daemon

Maybe we should document it elsewhere, too.. it wasn't a straightforward solution..