### PR TITLE
[runtime] fix standalone build: enable encointer-primitives `serde_derive` feature

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -104,6 +104,7 @@ std = [
 	"pallet-encointer-bazaar/std",
     "pallet-encointer-bazaar-rpc-runtime-api/std",
     "encointer-primitives/std",
+    "encointer-primitives/serde_derive",
 ]
 runtime-benchmarks = [
     "frame-benchmarking",


### PR DESCRIPTION
Maybe it was a stupid idea to not enable `serde_derive` in std by default...

Probably, at least the pallets that need the feature enabled in std, should enable it then.