### PR TITLE
Enable sending privileged extrinsics with a council-proposal

### DIFF
--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -109,7 +109,7 @@ def main(ipfs_local, client, port, spec_file):
 
     print("Claiming rewards")
     client.claim_reward(account1, cid)
-    client.await_block()
+    client.await_block(blocks_to_wait)
 
     print(f'Balances for new community with cid: {cid}.')
     bal = [client.balance(a, cid=cid) for a in accounts]

--- a/client/src/community_spec.rs
+++ b/client/src/community_spec.rs
@@ -113,8 +113,11 @@ impl CommunitySpec for serde_json::Value {
 	}
 }
 
+type NewCommunityCall =
+	([u8; 2], Location, Vec<AccountId>, CommunityMetadata, Option<Demurrage>, Option<BalanceType>);
+
 /// Extracts all the info from `spec` to create a `new_community` call.
-pub fn new_community_call<T: CommunitySpec>(spec: &T, metadata: &Metadata) -> impl Encode + Clone {
+pub fn new_community_call<T: CommunitySpec>(spec: &T, metadata: &Metadata) -> NewCommunityCall {
 	debug!("meta: {:?}", spec.community());
 
 	let bootstrappers = spec.bootstrappers();

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -31,8 +31,7 @@ use crate::{
 		batch_call, collective_propose_call, contains_sudo_pallet, ensure_payment,
 		into_effective_cindex,
 		keys::{get_accountid_from_str, get_pair_from_str},
-		offline_xt, print_raw_call, send_and_wait_for_in_block, send_xt_hex_and_wait_for_in_block,
-		sudo_call, xt, OpaqueCall,
+		offline_xt, print_raw_call, send_and_wait_for_in_block, sudo_call, xt, OpaqueCall,
 	},
 };
 use clap::{value_t, AppSettings, Arg, ArgMatches};
@@ -474,22 +473,22 @@ fn main() {
                     );
 
                     // return xt's as string to get same return types for if and else arm
-                    let next_phase_xt = if contains_sudo_pallet(&api.metadata) {
+                    let next_phase_call = if contains_sudo_pallet(&api.metadata) {
                         let sudo_next_phase_call = sudo_call(&api.metadata, next_phase_call);
                         info!("Printing raw sudo call for js/apps:");
                         print_raw_call("sudo(next_phase)", &sudo_next_phase_call);
 
-                        xt(&api, sudo_next_phase_call).hex_encode()
+                        OpaqueCall::from_tuple(&sudo_next_phase_call)
 
                     } else {
                         info!("Printing raw collective propose calls for js/apps");
                         let propose_next_phase = collective_propose_call(&api.metadata, 1, next_phase_call);
                         print_raw_call("collective_propose(next_phase)", &propose_next_phase);
 
-                        xt(&api, propose_next_phase).hex_encode()
+                        OpaqueCall::from_tuple(&propose_next_phase)
                     };
 
-                    send_xt_hex_and_wait_for_in_block(&api, next_phase_xt);
+                    send_and_wait_for_in_block(&api, xt(&api, next_phase_call));
 
                     let phase = api.get_current_phase().unwrap();
                     println!("Phase is now: {:?}", phase);

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -375,7 +375,7 @@ fn main() {
                     let add_location_calls = spec.locations().into_iter().skip(1).map(|l| add_location_call(&api.metadata, cid, l)).collect();
                     let add_location_batch_call = batch_call(&api.metadata, add_location_calls);
 
-                    // return xt's as string to get same return types for if and else arm
+                    // return calls as `OpaqueCall`s to get the same return type in both branches
                     let (new_community_call, add_location_batch_call) = if contains_sudo_pallet(&api.metadata) {
                         let sudo_new_community = sudo_call(&api.metadata, new_community_call);
                         let sudo_add_location_batch = sudo_call(&api.metadata, add_location_batch_call);
@@ -472,7 +472,7 @@ fn main() {
                         "next_phase"
                     );
 
-                    // return xt's as string to get same return types for if and else arm
+                    // return calls as `OpaqueCall`s to get the same return type in both branches
                     let next_phase_call = if contains_sudo_pallet(&api.metadata) {
                         let sudo_next_phase_call = sudo_call(&api.metadata, next_phase_call);
                         info!("Printing raw sudo call for js/apps:");

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -396,7 +396,7 @@ fn main() {
                     };
 
                     // ---- send xt's to chain
-                    send_and_wait_for_in_block(&api, xt(&api,new_community_call));
+                    send_and_wait_for_in_block(&api, xt(&api, new_community_call));
                     println!("{}", cid);
 
                     if api.get_current_phase().unwrap() != CeremonyPhaseType::REGISTERING {
@@ -404,7 +404,7 @@ fn main() {
                         error!("Aborting without registering additional locations");
                         std::process::exit(exit_code::WRONG_PHASE);
                     }
-                    send_and_wait_for_in_block(&api, xt(&api,add_location_batch_call));
+                    send_and_wait_for_in_block(&api, xt(&api, add_location_batch_call));
                     Ok(())
                 }),
         )

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -393,11 +393,13 @@ fn main() {
 
                     } else {
                         info!("Printing raw collective propose calls for js/apps for cid: {}", cid);
-                        print_raw_call("collective_propose(new_community)", &collective_propose_call(&api.metadata, 1, new_community_call.clone()));
-                        print_raw_call("collective_propose(utility_batch(add_location))", &collective_propose_call(&api.metadata, 1, add_location_batch_call.clone()));
+                        let propose_new_community = collective_propose_call(&api.metadata, 1, new_community_call);
+                        let propose_add_location_batch = collective_propose_call(&api.metadata, 1, add_location_batch_call);
+                        print_raw_call("collective_propose(new_community)", &propose_new_community);
+                        print_raw_call("collective_propose(utility_batch(add_location))", &propose_add_location_batch);
 
                         // ---- send xt's to chain
-                        send_and_wait_for_in_block(&api, xt(&api, new_community_call));
+                        send_and_wait_for_in_block(&api, xt(&api, propose_new_community));
                         println!("{}", cid);
 
                         if api.get_current_phase().unwrap() != CeremonyPhaseType::REGISTERING {
@@ -406,7 +408,7 @@ fn main() {
                             std::process::exit(exit_code::WRONG_PHASE);
                         }
 
-                        send_and_wait_for_in_block(&api, xt(&api, add_location_batch_call));
+                        send_and_wait_for_in_block(&api, xt(&api, propose_add_location_batch));
                     }
                     Ok(())
                 }),

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -66,7 +66,7 @@ pub fn collective_propose_call<Proposal: Encode>(
 	metadata: &Metadata,
 	threshold: u32,
 	proposal: Proposal,
-) -> ([u8; 2], u32, Proposal, u32) {
+) -> CollectiveProposeCall<Proposal> {
 	let length_bound = proposal.encode().len() as u32 + 4;
 	compose_call!(metadata, "Collective", "propose", threshold, proposal, length_bound)
 }

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -5,8 +5,8 @@ use log::{debug, error, info};
 use sp_application_crypto::sr25519;
 use sp_core::{Pair, H256};
 use substrate_api_client::{
-	compose_call, compose_extrinsic, compose_extrinsic_offline, rpc::WsRpcClient, Api, Metadata,
-	UncheckedExtrinsicV4, XtStatus,
+	compose_call, compose_extrinsic_offline, rpc::WsRpcClient, Api, Metadata, UncheckedExtrinsicV4,
+	XtStatus,
 };
 
 /// Wrapper around the `compose_extrinsic_offline!` macro to be less verbose.
@@ -41,13 +41,6 @@ pub fn xt<C: Encode + Clone>(
 /// Wraps the supplied call in a sudo call
 pub fn sudo_call<C: Encode + Clone>(metadata: &Metadata, call: C) -> ([u8; 2], C) {
 	compose_call!(metadata, "Sudo", "sudo", call)
-}
-
-pub fn sudo_xt<C: Encode + Clone>(
-	api: &Api<sr25519::Pair, WsRpcClient>,
-	call: C,
-) -> UncheckedExtrinsicV4<([u8; 2], C)> {
-	compose_extrinsic!(api, "Sudo", "sudo", call)
 }
 
 /// Wraps the supplied calls in a batch call
@@ -153,6 +146,22 @@ pub fn into_effective_cindex(
 		i32::MIN..=-1 => current_ceremony_index - ceremony_index.abs() as u32,
 		1..=i32::MAX => ceremony_index as CeremonyIndexType,
 		0 => panic!("Zero not allowed as ceremony index"),
+	}
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct OpaqueCall(pub Vec<u8>);
+
+impl OpaqueCall {
+	/// Convert a call to an `OpaqueCall`.
+	pub fn from_tuple<C: Encode>(call: &C) -> Self {
+		OpaqueCall(call.encode())
+	}
+}
+
+impl Encode for OpaqueCall {
+	fn encode(&self) -> Vec<u8> {
+		self.0.clone()
 	}
 }
 

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -82,8 +82,15 @@ pub fn send_and_wait_for_in_block<C: Encode>(
 	api: &Api<sr25519::Pair, WsRpcClient>,
 	xt: UncheckedExtrinsicV4<C>,
 ) -> Option<H256> {
-	ensure_payment(&api, &xt.hex_encode());
-	let tx_hash = api.send_extrinsic(xt.hex_encode(), XtStatus::InBlock).unwrap();
+	send_xt_hex_and_wait_for_in_block(api, xt.hex_encode())
+}
+
+pub fn send_xt_hex_and_wait_for_in_block(
+	api: &Api<sr25519::Pair, WsRpcClient>,
+	xt_hex: String,
+) -> Option<H256> {
+	ensure_payment(&api, &xt_hex);
+	let tx_hash = api.send_extrinsic(xt_hex, XtStatus::InBlock).unwrap();
 	info!("[+] Transaction got included. Hash: {:?}\n", tx_hash);
 
 	tx_hash

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -151,8 +151,8 @@ pub fn into_effective_cindex(
 
 /// Simple blob to hold a call in encoded format.
 ///
-/// Useful for managing a set of extrinsic with different calls without running into rust's type
-/// problem.
+/// Useful for managing a set of extrinsic with different calls without having problems with rust's
+/// type system.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct OpaqueCall(pub Vec<u8>);
 

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::exit_code;
-use codec::Encode;
+use codec::{Compact, Encode};
 use encointer_primitives::scheduler::CeremonyIndexType;
 use log::{debug, error, info};
 use sp_application_crypto::sr25519;
@@ -59,7 +59,7 @@ pub fn batch_call<C: Encode + Clone>(metadata: &Metadata, calls: Vec<C>) -> ([u8
 ///
 /// `threshold` is the number of members. threshold < 1 will make the proposal be executed directly.
 /// `length_bound` must be >= `Proposal.encode().len() + (size_of::<u32>() == 4)`
-type CollectiveProposeCall<Proposal> = ([u8; 2], u32, Proposal, u32);
+type CollectiveProposeCall<Proposal> = ([u8; 2], Compact<u32>, Proposal, Compact<u32>);
 
 /// Creates a council propose call
 pub fn collective_propose_call<Proposal: Encode>(
@@ -68,7 +68,14 @@ pub fn collective_propose_call<Proposal: Encode>(
 	proposal: Proposal,
 ) -> CollectiveProposeCall<Proposal> {
 	let length_bound = proposal.encode().len() as u32 + 4;
-	compose_call!(metadata, "Collective", "propose", threshold, proposal, length_bound)
+	compose_call!(
+		metadata,
+		"Collective",
+		"propose",
+		Compact(threshold),
+		proposal,
+		Compact(length_bound)
+	)
 }
 
 pub fn send_and_wait_for_in_block<C: Encode>(

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -149,6 +149,10 @@ pub fn into_effective_cindex(
 	}
 }
 
+/// Simple blob to hold a call in encoded format.
+///
+/// Useful for managing a set of extrinsic with different calls without running into rust's type
+/// problem.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct OpaqueCall(pub Vec<u8>);
 

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -82,6 +82,11 @@ pub fn send_and_wait_for_in_block<C: Encode>(
 	tx_hash
 }
 
+/// Prints the raw call to be supplied with js/apps.
+pub fn print_raw_call<Call: Encode>(name: &str, call: &Call) {
+	info!("{}: 0x{}", name, hex::encode(call.encode()));
+}
+
 /// Checks if the sudo pallet exists on chain.
 ///
 /// This will implicitly distinguish between solo-chain (sudo exists) and parachain


### PR DESCRIPTION
When the `sudo` pallet does not exist, we infer that we are talking to a chain with the `collective` pallet where `Alice` is the sole member. Privileged calls are sent as a council proposal as `Alice` leading to immediate execution of the proposal if successful.

Tested against encointer-parachain with Alice as sole council member:
* `new-community` and `next-phase` CLI work
* `bootstrap_demo_community.py` runs successfully