### PR TITLE
add cli command to set signed meetup time offset

### DIFF
--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -11,6 +11,7 @@ const FUNDEES_ARG: &'static str = "fundees";
 const FROM_CINDEX_ARG: &'static str = "from-cindex";
 const TO_CINDEX_ARG: &'static str = "to-cindex";
 const ENDORSEES_ARG: &'static str = "endorsees";
+const TIME_OFFSET_ARG: &'static str = "time-offset";
 const ALL_FLAG: &'static str = "all";
 
 pub trait EncointerArgs<'b> {
@@ -25,6 +26,7 @@ pub trait EncointerArgs<'b> {
 	fn from_cindex_arg(self) -> Self;
 	fn to_cindex_arg(self) -> Self;
 	fn endorsees_arg(self) -> Self;
+	fn time_offset_arg(self) -> Self;
 	fn all_flag(self) -> Self;
 }
 
@@ -40,6 +42,7 @@ pub trait EncointerArgsExtractor {
 	fn from_cindex_arg(&self) -> Option<i32>;
 	fn to_cindex_arg(&self) -> Option<i32>;
 	fn endorsees_arg(&self) -> Option<Vec<&str>>;
+	fn time_offset_arg(&self) -> Option<i32>;
 	fn all_flag(&self) -> bool;
 }
 
@@ -160,7 +163,15 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 				.help("Account(s) to be endorsed, ss58check encoded"),
 		)
 	}
-
+	fn time_offset_arg(self) -> Self {
+		self.arg(
+			Arg::with_name(TIME_OFFSET_ARG)
+				.takes_value(true)
+				.required(true)
+				.value_name("TIME_OFFSET")
+				.help("signed value in milliseconds"),
+		)
+	}
 	fn all_flag(self) -> Self {
 		self.arg(
 			Arg::with_name(ALL_FLAG)
@@ -217,6 +228,9 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 		self.values_of(ENDORSEES_ARG).map(|v| v.collect())
 	}
 
+	fn time_offset_arg(&self) -> Option<i32> {
+		self.value_of(TIME_OFFSET_ARG).map(|v| v.parse().unwrap())
+	}
 	fn all_flag(&self) -> bool {
 		self.is_present(ALL_FLAG)
 	}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1089,8 +1089,9 @@ fn main() {
                         print_raw_call("sudo(...)", &sudo_call);
                         OpaqueCall::from_tuple(&sudo_call)
                     } else {
-                        info!("Printing raw collective propose calls for js/apps");
-                        let propose_call = collective_propose_call(&api.metadata, 1, call);
+                        let threshold = (get_councillors(&api).unwrap().len() / 2 + 1) as u32;
+                        info!("Printing raw collective propose calls with threshold {} for js/apps", threshold);
+                        let propose_call = collective_propose_call(&api.metadata, threshold, call);
                         print_raw_call("collective_propose(...)", &propose_call);
                         OpaqueCall::from_tuple(&propose_call)
                     };

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1063,7 +1063,42 @@ fn main() {
                     Ok(())
                 }),
         )
+        .add_cmd(
+            Command::new("set-meetup-time-offset")
+                .description("signed value to offset the ceremony meetup time relative to solar noon")
+                .options(|app| {
+                    app.setting(AppSettings::ColoredHelp)
+                        .setting(AppSettings::AllowLeadingHyphen)
+                        .time_offset_arg()
+                })
+                .runner(|_args: &str, matches: &ArgMatches<'_>| {
+                    let api = get_chain_api(matches)
+                        .set_signer(AccountKeyring::Alice.pair());
+                    let time_offset = matches.time_offset_arg().unwrap_or(0);
+                    let call = compose_call!(
+                        &api.metadata,
+                        "EncointerCeremonies",
+                        "set_meetup_time_offset",
+                        time_offset
+                    );
 
+                    // return calls as `OpaqueCall`s to get the same return type in both branches
+                    let privileged_call = if contains_sudo_pallet(&api.metadata) {
+                        let sudo_call = sudo_call(&api.metadata, call);
+                        info!("Printing raw sudo call for js/apps:");
+                        print_raw_call("sudo(...)", &sudo_call);
+                        OpaqueCall::from_tuple(&sudo_call)
+                    } else {
+                        info!("Printing raw collective propose calls for js/apps");
+                        let propose_call = collective_propose_call(&api.metadata, 1, call);
+                        print_raw_call("collective_propose(...)", &propose_call);
+                        OpaqueCall::from_tuple(&propose_call)
+                    };
+
+                    send_and_wait_for_in_block(&api, xt(&api, privileged_call));
+                    Ok(())
+                }),
+        )
         // To handle when no subcommands match
         .no_cmd(|_args, _matches| {
             println!("No subcommand matched");


### PR DESCRIPTION
adds a new cli command to set meetup time offset.
This is necessary as [js/apps doesn't support `i32` as input arg to extrinsics](https://github.com/polkadot-js/apps/issues/5920)

Unfortunately, also the parse_duration crate works with `std::time::Duration` which doesn't support negative durations, so I had to fall back to only allowing a signed millisecond value as input