### PR TITLE
bump substrate and api-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,6 +1461,7 @@ dependencies = [
 name = "encointer-api-client-extension"
 version = "0.8.2"
 dependencies = [
+ "ac-primitives",
  "encointer-ceremonies-assignment",
  "encointer-primitives",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.1.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=cl/better-generics#d0245699b49ebc6b7a59673cd54c7ec80af8f1a2"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#714fb1d1d89bce6e6322ef1e5aebfbb6919618dc"
 dependencies = [
  "ac-primitives",
  "log",
@@ -27,7 +27,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.1.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=cl/better-generics#d0245699b49ebc6b7a59673cd54c7ec80af8f1a2"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#714fb1d1d89bce6e6322ef1e5aebfbb6919618dc"
 dependencies = [
  "ac-primitives",
  "frame-metadata",
@@ -47,7 +47,7 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.1.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=cl/better-generics#d0245699b49ebc6b7a59673cd54c7ec80af8f1a2"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#714fb1d1d89bce6e6322ef1e5aebfbb6919618dc"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -7736,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.6.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=cl/better-generics#d0245699b49ebc6b7a59673cd54c7ec80af8f1a2"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#714fb1d1d89bce6e6322ef1e5aebfbb6919618dc"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -7787,7 +7787,7 @@ dependencies = [
 [[package]]
 name = "substrate-client-keystore"
 version = "0.6.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=cl/better-generics#d0245699b49ebc6b7a59673cd54c7ec80af8f1a2"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#714fb1d1d89bce6e6322ef1e5aebfbb6919618dc"
 dependencies = [
  "async-trait",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,6 +1476,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1491,6 +1492,7 @@ dependencies = [
 [[package]]
 name = "encointer-ceremonies-assignment"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -1630,6 +1632,7 @@ dependencies = [
 [[package]]
 name = "encointer-primitives"
 version = "1.1.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "bs58",
  "concat-arrays",
@@ -1649,6 +1652,7 @@ dependencies = [
 [[package]]
 name = "encointer-rpc"
 version = "0.1.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "jsonrpsee",
  "thiserror",
@@ -1688,6 +1692,7 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 [[package]]
 name = "ep-core"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -4375,6 +4380,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-balances"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4393,6 +4399,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar"
 version = "1.1.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4409,6 +4416,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4427,6 +4435,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4437,6 +4446,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies"
 version = "1.1.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-primitives",
@@ -4460,6 +4470,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4478,6 +4489,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4488,6 +4500,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities"
 version = "1.1.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4506,6 +4519,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4524,6 +4538,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "encointer-primitives",
  "sp-api",
@@ -4533,6 +4548,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-scheduler"
 version = "1.1.0"
+source = "git+https://github.com/encointer/pallets?branch=master#88254b23f1c9547649200ba0ad58b4841bc58f02"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.1.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=cl/encointer-community-currency-fees-hotfix#b51d802b054bbd655b3178448822e2db04a8a71e"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#edf0c13b05e43d9550a0a3773915c7bee74a48b5"
 dependencies = [
  "ac-primitives",
  "log",
@@ -27,7 +27,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.1.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=cl/encointer-community-currency-fees-hotfix#b51d802b054bbd655b3178448822e2db04a8a71e"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#edf0c13b05e43d9550a0a3773915c7bee74a48b5"
 dependencies = [
  "ac-primitives",
  "frame-metadata",
@@ -47,9 +47,8 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.1.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=cl/encointer-community-currency-fees-hotfix#b51d802b054bbd655b3178448822e2db04a8a71e"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#edf0c13b05e43d9550a0a3773915c7bee74a48b5"
 dependencies = [
- "encointer-primitives",
  "hex",
  "parity-scale-codec",
  "sp-core",
@@ -7720,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.6.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=cl/encointer-community-currency-fees-hotfix#b51d802b054bbd655b3178448822e2db04a8a71e"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#edf0c13b05e43d9550a0a3773915c7bee74a48b5"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -7771,7 +7770,7 @@ dependencies = [
 [[package]]
 name = "substrate-client-keystore"
 version = "0.6.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=cl/encointer-community-currency-fees-hotfix#b51d802b054bbd655b3178448822e2db04a8a71e"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#edf0c13b05e43d9550a0a3773915c7bee74a48b5"
 dependencies = [
  "async-trait",
  "hex",
@@ -8327,7 +8326,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,7 +1461,6 @@ dependencies = [
 name = "encointer-api-client-extension"
 version = "0.8.2"
 dependencies = [
- "ac-primitives",
  "encointer-ceremonies-assignment",
  "encointer-primitives",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
- "cpufeatures 0.2.1",
+ "cpufeatures",
  "opaque-debug 0.3.0",
 ]
 
@@ -239,7 +239,7 @@ dependencies = [
  "parking",
  "polling",
  "slab",
- "socket2 0.4.4",
+ "socket2",
  "waker-fn",
  "winapi 0.3.9",
 ]
@@ -263,6 +263,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2c06e30a24e8c78a3987d07f0930edf76ef35e027e7bdb063fccafdad1f60c"
+dependencies = [
+ "async-io",
+ "blocking",
+ "cfg-if 1.0.0",
+ "event-listener",
+ "futures-lite",
+ "libc",
+ "once_cell",
+ "signal-hook",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "async-std"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +289,7 @@ dependencies = [
  "async-global-executor",
  "async-io",
  "async-lock",
+ "async-process",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
@@ -291,15 +309,16 @@ dependencies = [
 
 [[package]]
 name = "async-std-resolver"
-version = "0.20.4"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf3e776afdf3a2477ef4854b85ba0dff3bd85792f685fb3c68948b4d304e4f0"
+checksum = "0f2f8a4a203be3325981310ab243a28e6e4ea55b6519bffce05d41ab60e09ad8"
 dependencies = [
  "async-std",
  "async-trait",
  "futures-io",
  "futures-util",
  "pin-utils",
+ "socket2",
  "trust-dns-resolver",
 ]
 
@@ -318,19 +337,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "asynchronous-codec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4401f0a3622dad2e0763fa79e0eb328bc70fb7dccfdd645341f00d671247d6"
-dependencies = [
- "bytes 1.1.0",
- "futures-sink",
- "futures-util",
- "memchr",
- "pin-project-lite 0.2.8",
 ]
 
 [[package]]
@@ -400,6 +406,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +422,15 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bimap"
@@ -465,17 +486,6 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
-dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "blake2"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
@@ -495,39 +505,37 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.11"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec 0.7.2",
  "constant_time_eq",
 ]
 
 [[package]]
 name = "blake2s_simd"
-version = "0.5.11"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
+checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec 0.7.2",
  "constant_time_eq",
 ]
 
 [[package]]
 name = "blake3"
-version = "0.3.8"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64485778c4f16a6a5a9d335e80d449ac6c70cdd6a06d2af18a6f6f775a125b3"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec 0.7.2",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "constant_time_eq",
- "crypto-mac 0.8.0",
- "digest 0.9.0",
 ]
 
 [[package]]
@@ -734,21 +742,21 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee7ad89dc1128635074c268ee661f90c3f7e83d9fd12910608c36b47d6c3412"
+checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
- "cpufeatures 0.1.5",
+ "cpufeatures",
  "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580317203210c517b6d44794abfbe600698276db18127e37ad3e69bf5e848e5"
+checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
 dependencies = [
  "aead",
  "chacha20",
@@ -772,13 +780,15 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.6.1"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff0e3bc0b6446b3f9663c1a6aba6ef06c5aeaa1bc92bd18077be337198ab9768"
+checksum = "fc949bff6704880faf064c42a4854032ab07bfcf3a4fcb82a57470acededb69c"
 dependencies = [
+ "core2",
  "multibase",
- "multihash 0.13.2",
- "unsigned-varint 0.5.1",
+ "multihash",
+ "serde",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -818,16 +828,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.6"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
@@ -844,15 +854,35 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.4"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "comfy-table"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b103d85ca6e209388771bfb7aa6b68a7aeec4afbf6f0a0264bfbf50360e5212e"
+dependencies = [
+ "strum",
+ "strum_macros",
+ "unicode-width",
 ]
 
 [[package]]
@@ -874,6 +904,12 @@ checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "constant_time_eq"
@@ -904,21 +940,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpp_demangle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -932,18 +968,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.80.1"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fc68cdb867b7d27b5f33cd65eb11376dfb41a2d09568a1a2c2bc1dc204f4ef"
+checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.80.1"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31253a44ab62588f8235a996cc9b0636d98a299190069ced9628b8547329b47a"
+checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -958,33 +994,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.80.1"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a20ab4627d30b702fb1b8a399882726d216b8164d3b3fa6189e3bf901506afe"
+checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.80.1"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6687d9668dacfed4468361f7578d86bded8ca4db978f734d9b631494bebbb5b8"
+checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.80.1"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77c5d72db97ba2cb36f69037a709edbae0d29cb25503775891e7151c5c874bf"
+checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.80.1"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426dca83f63c7c64ea459eb569aadc5e0c66536c0042ed5d693f91830e8750d0"
+checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -994,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.80.1"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8007864b5d0c49b026c861a15761785a2871124e401630c03ef1426e6d0d559e"
+checksum = "501241b0cdf903412ec9075385ac9f2b1eb18a89044d1538e97fab603231f70c"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1005,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.80.1"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cf12c071415ba261d897387ae5350c4d83c238376c8c5a96514ecfa2ea66a3"
+checksum = "16d9e4211bbc3268042a96dd4de5bd979cda22434991d035f5f8eacba987fad2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1094,6 +1130,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+dependencies = [
+ "generic-array 0.14.5",
+ "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,15 +1169,6 @@ checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array 0.14.5",
  "subtle",
-]
-
-[[package]]
-name = "ct-logs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
-dependencies = [
- "sct",
 ]
 
 [[package]]
@@ -1189,6 +1228,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4033478fbf70d6acf2655ac70da91ee65852d69daf7a67bf7a2f518fb47aafcf"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1264,15 @@ checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
  "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid",
 ]
 
 [[package]]
@@ -1315,9 +1376,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dtoa"
-version = "0.4.8"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+checksum = "5caaa75cbd2b960ff1e5392d2cfb1f44717fffe12fc1f32b7b5d1267f99732a6"
 
 [[package]]
 name = "dyn-clonable"
@@ -1345,6 +1406,18 @@ name = "dyn-clone"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
+name = "ecdsa"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
 
 [[package]]
 name = "ed25519"
@@ -1376,6 +1449,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "elliptic-curve"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "der",
+ "ff",
+ "generic-array 0.14.5",
+ "group",
+ "rand_core 0.6.3",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "encointer-api-client-extension"
 version = "0.8.2"
 dependencies = [
@@ -1392,7 +1483,6 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1408,7 +1498,6 @@ dependencies = [
 [[package]]
 name = "encointer-ceremonies-assignment"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -1446,10 +1535,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "encointer-meetup-validation"
+version = "1.0.0"
+dependencies = [
+ "encointer-primitives",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "encointer-node-notee"
 version = "0.8.6"
 dependencies = [
- "clap 3.1.6",
+ "clap 3.1.18",
  "encointer-node-notee-runtime",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -1542,7 +1640,6 @@ dependencies = [
 [[package]]
 name = "encointer-primitives"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "bs58",
  "concat-arrays",
@@ -1561,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570d109b813e904becc80d8d5da38376818a143348413f7149f1340fe04754d4"
+checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -1593,7 +1690,6 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 [[package]]
 name = "ep-core"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -1669,6 +1765,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4c9e43643f5a3be4ca5b67d26b98031ff9db6806c3440ae32e02e3ceac3f1b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ff"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
+dependencies = [
+ "rand_core 0.6.3",
+ "subtle",
 ]
 
 [[package]]
@@ -1752,7 +1858,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1770,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1792,29 +1898,34 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "Inflector",
  "chrono",
- "clap 3.1.6",
+ "clap 3.1.18",
+ "comfy-table",
  "frame-benchmarking",
  "frame-support",
+ "frame-system",
  "handlebars",
  "hash-db",
  "hex",
  "itertools",
  "kvdb",
+ "lazy_static",
  "linked-hash-map",
  "log",
  "memory-db",
  "parity-scale-codec",
  "rand 0.8.5",
+ "rand_pcg 0.3.1",
  "sc-block-builder",
  "sc-cli",
  "sc-client-api",
  "sc-client-db",
  "sc-executor",
  "sc-service",
+ "sc-sysinfo",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -1827,15 +1938,17 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
- "sp-std",
  "sp-storage",
  "sp-trie",
+ "tempfile",
+ "thiserror",
+ "thousands",
 ]
 
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1863,12 +1976,13 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "bitflags",
  "frame-metadata",
  "frame-support-procedural",
  "impl-trait-for-tuples",
+ "k256",
  "log",
  "once_cell",
  "parity-scale-codec",
@@ -1892,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1904,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.1.3",
@@ -1916,7 +2030,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1926,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support",
  "log",
@@ -1943,7 +2057,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1958,7 +2072,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2097,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "futures-rustls"
-version = "0.21.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1387e07917c711fb4ee4f48ea0adb04a3c9739e53ef85bf43ae1edc2937a8b"
+checksum = "e01fe9932a224b72b45336d96040aa86386d674a31d0af27d800ea7bc8ca97fe"
 dependencies = [
  "futures-io",
  "rustls",
@@ -2260,6 +2374,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+dependencies = [
+ "ff",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,7 +2399,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -2466,7 +2591,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.1",
  "pin-project-lite 0.2.8",
- "socket2 0.4.4",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2475,19 +2600,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
- "ct-logs",
- "futures-util",
+ "http",
  "hyper",
  "log",
  "rustls",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
- "webpki",
 ]
 
 [[package]]
@@ -2514,39 +2637,30 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.6.7"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2273e421f7c4f0fc99e1934fe4776f59d8df2972f4199d703fc0da9f2a9f73de"
+checksum = "cbc0fa01ffc752e9dbc72818cdb072cd028b86be5e09dd04c5a643704fe101a9"
 dependencies = [
- "if-addrs-sys",
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "if-addrs-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de74b9dd780476e837e5eb5ab7c88b49ed304126e412030a0adba99c8efe79ea"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
 name = "if-watch"
-version = "0.2.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8ab7f67bad3240049cb24fb9cb0b4c2c6af4c245840917fbbdededeee91179"
+checksum = "ae8f4a3c3d4c89351ca83e120c1c00b27df945d38e05695668c9d4b4f7bc52f3"
 dependencies = [
  "async-io",
+ "core-foundation",
+ "fnv",
  "futures 0.3.21",
- "futures-lite",
  "if-addrs",
  "ipnet",
- "libc",
  "log",
- "winapi 0.3.9",
+ "rtnetlink",
+ "system-configuration",
+ "windows",
 ]
 
 [[package]]
@@ -2609,12 +2723,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.4.4"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ef6787e7f0faedc040f95716bdd0e62bcfcf4ba93da053b62dea2691c13864"
-dependencies = [
- "winapi 0.3.9",
-]
+checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
 
 [[package]]
 name = "iovec"
@@ -2633,11 +2744,11 @@ checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
 
 [[package]]
 name = "ipconfig"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
+checksum = "723519edce41262b05d4143ceb95050e4c614f483e78e9fd9e39a8275a84ad98"
 dependencies = [
- "socket2 0.3.19",
+ "socket2",
  "widestring",
  "winapi 0.3.9",
  "winreg",
@@ -2742,37 +2853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-http-server"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
-dependencies = [
- "futures 0.3.21",
- "hyper",
- "jsonrpc-core",
- "jsonrpc-server-utils",
- "log",
- "net2",
- "parking_lot 0.11.2",
- "unicase",
-]
-
-[[package]]
-name = "jsonrpc-ipc-server"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382bb0206323ca7cda3dcd7e245cea86d37d02457a02a975e3378fb149a48845"
-dependencies = [
- "futures 0.3.21",
- "jsonrpc-core",
- "jsonrpc-server-utils",
- "log",
- "parity-tokio-ipc",
- "parking_lot 0.11.2",
- "tower-service",
-]
-
-[[package]]
 name = "jsonrpc-pubsub"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2788,36 +2868,116 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-server-utils"
-version = "18.0.0"
+name = "jsonrpsee"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
+checksum = "a1f2ab5a60e558e74ea93bcf5164ebc47939a7fff8938fa9b5233bbc63e16061"
 dependencies = [
- "bytes 1.1.0",
- "futures 0.3.21",
- "globset",
- "jsonrpc-core",
- "lazy_static",
- "log",
+ "jsonrpsee-core",
+ "jsonrpsee-http-server",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types",
+ "jsonrpsee-ws-server",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e27462b21279edf9a6a91f46ffbe125e9cdc58b901d2e08bf59b31a47d7d0ab"
+dependencies = [
+ "anyhow",
+ "arrayvec 0.7.2",
+ "async-trait",
+ "beef",
+ "futures-channel",
+ "futures-util",
+ "hyper",
+ "jsonrpsee-types",
+ "parking_lot 0.12.0",
+ "rand 0.8.5",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror",
  "tokio",
- "tokio-stream",
- "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-server"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7178f16eabd7154c094e24d295b9ee355ec1e5f24c328759c56255ff7bbd4548"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "globset",
+ "hyper",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "lazy_static",
+ "serde_json",
+ "tokio",
+ "tracing",
  "unicase",
 ]
 
 [[package]]
-name = "jsonrpc-ws-server"
-version = "18.0.0"
+name = "jsonrpsee-proc-macros"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f892c7d766369475ab7b0669f417906302d7c0fb521285c0a0c92e52e7c8e946"
+checksum = "8b8d7f449cab3b747f12c3efc27f5cad537f3b597c6a3838b0fac628f4bf730a"
 dependencies = [
- "futures 0.3.21",
- "jsonrpc-core",
- "jsonrpc-server-utils",
- "log",
- "parity-ws",
- "parking_lot 0.11.2",
- "slab",
+ "proc-macro-crate 1.1.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd11763134104122ddeb0f97e4bbe393058017dfb077db63fbf44b4dd0dd86e"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-ws-server"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfb6c21556c551582b56e4e8e6e6249b0bbdb69bb7fa39efe9b9a6b54af9f206"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "serde_json",
+ "soketto",
+ "tokio",
+ "tokio-util 0.7.2",
+ "tracing",
+]
+
+[[package]]
+name = "k256"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa",
+ "elliptic-curve",
+ "sec1",
 ]
 
 [[package]]
@@ -2930,14 +3090,18 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "libp2p"
-version = "0.40.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bec54343492ba5940a6c555e512c6721139835d28c59bc22febece72dfd0d9d"
+checksum = "475ce2ac4a9727e53a519f6ee05b38abfcba8f0d39c4d24f103d184e36fd5b0f"
 dependencies = [
  "atomic",
  "bytes 1.1.0",
  "futures 0.3.21",
+ "futures-timer",
+ "getrandom 0.2.5",
+ "instant",
  "lazy_static",
+ "libp2p-autonat",
  "libp2p-core",
  "libp2p-deflate",
  "libp2p-dns",
@@ -2963,17 +3127,36 @@ dependencies = [
  "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "pin-project 1.0.10",
+ "rand 0.7.3",
  "smallvec",
- "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-autonat"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13b690e65046af6a09c0b27bd9508fa1cab0efce889de74b0b643b9d2a98f9a"
+dependencies = [
+ "async-trait",
+ "futures 0.3.21",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "log",
+ "prost 0.9.0",
+ "prost-build",
+ "rand 0.8.5",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.30.2"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86aad7d54df283db817becded03e611137698a6509d4237a96881976a162340c"
+checksum = "db5b02602099fb75cb2d16f9ea860a320d6eb82ce41e95ab680912c454805cd5"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2987,28 +3170,28 @@ dependencies = [
  "libsecp256k1",
  "log",
  "multiaddr",
- "multihash 0.14.0",
+ "multihash",
  "multistream-select",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "pin-project 1.0.10",
- "prost",
+ "prost 0.9.0",
  "prost-build",
  "rand 0.8.5",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.9",
+ "sha2 0.10.2",
  "smallvec",
  "thiserror",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
  "void",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-deflate"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51a800adb195f33de63f4b17b63fe64cfc23bf2c6a0d3d0d5321328664e65197"
+checksum = "6b1d37f042f748e224f04785d0e987ae09a2aa518d6401d82d412dad83e360ed"
 dependencies = [
  "flate2",
  "futures 0.3.21",
@@ -3017,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.30.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb8f89d15cb6e3c5bc22afff7513b11bab7856f2872d3cfba86f7f63a06bc498"
+checksum = "066e33e854e10b5c93fc650458bf2179c7e0d143db260b0963e44a94859817f1"
 dependencies = [
  "async-std-resolver",
  "futures 0.3.21",
@@ -3031,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.31.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab3d7210901ea51b7bae2b581aa34521797af8c4ec738c980bda4a06434067f"
+checksum = "733d3ea6ebe7a7a85df2bc86678b93f24b015fae5fe3b3acc4c400e795a55d2d"
 dependencies = [
  "cuckoofilter",
  "fnv",
@@ -3041,7 +3224,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost",
+ "prost 0.9.0",
  "prost-build",
  "rand 0.7.3",
  "smallvec",
@@ -3049,78 +3232,82 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.33.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeead619eb5dac46e65acc78c535a60aaec803d1428cca6407c3a4fc74d698d"
+checksum = "a90c989a7c0969c2ab63e898da9bc735e3be53fb4f376e9c045ce516bcc9f928"
 dependencies = [
- "asynchronous-codec 0.6.0",
+ "asynchronous-codec",
  "base64",
  "byteorder",
  "bytes 1.1.0",
  "fnv",
  "futures 0.3.21",
  "hex_fmt",
+ "instant",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost",
+ "prometheus-client",
+ "prost 0.9.0",
  "prost-build",
  "rand 0.7.3",
  "regex",
- "sha2 0.9.9",
+ "sha2 0.10.2",
  "smallvec",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.31.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca1275574183f288ff8b72d535d5ffa5ea9292ef7829af8b47dcb197c7b0dcd"
+checksum = "c5ef5a5b57904c7c33d6713ef918d239dc6b7553458f3475d87f8a18e9c651c8"
 dependencies = [
  "futures 0.3.21",
+ "futures-timer",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "lru 0.6.6",
- "prost",
+ "lru",
+ "prost 0.9.0",
  "prost-build",
  "smallvec",
- "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-kad"
-version = "0.32.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2297dc0ca285f3a09d1368bde02449e539b46f94d32d53233f53f6625bcd3ba"
+checksum = "564e6bd64d177446399ed835b9451a8825b07929d6daa6a94e6405592974725e"
 dependencies = [
  "arrayvec 0.5.2",
- "asynchronous-codec 0.6.0",
+ "asynchronous-codec",
  "bytes 1.1.0",
  "either",
  "fnv",
  "futures 0.3.21",
+ "futures-timer",
+ "instant",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost",
+ "prost 0.9.0",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.9",
+ "sha2 0.10.2",
  "smallvec",
+ "thiserror",
  "uint",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
  "void",
- "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.32.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c864b64bdc8a84ff3910a0df88e6535f256191a450870f1e7e10cbf8e64d45"
+checksum = "611ae873c8e280ccfab0d57c7a13cac5644f364529e233114ff07863946058b0"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -3133,47 +3320,49 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.4.4",
+ "socket2",
  "void",
 ]
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.1.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af432fcdd2f8ba4579b846489f8f0812cfd738ced2c0af39df9b1c48bbb6ab2"
+checksum = "985be799bb3796e0c136c768208c3c06604a38430571906a13dcfeda225a3b9d"
 dependencies = [
  "libp2p-core",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-kad",
  "libp2p-ping",
+ "libp2p-relay",
  "libp2p-swarm",
- "open-metrics-client",
+ "prometheus-client",
 ]
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2cd64ef597f40e14bfce0497f50ecb63dd6d201c61796daeb4227078834fbf"
+checksum = "442eb0c9fff0bf22a34f015724b4143ce01877e079ed0963c722d94c07c72160"
 dependencies = [
- "asynchronous-codec 0.6.0",
+ "asynchronous-codec",
  "bytes 1.1.0",
  "futures 0.3.21",
  "libp2p-core",
  "log",
  "nohash-hasher",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "rand 0.7.3",
  "smallvec",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8772c7a99088221bb7ca9c5c0574bf55046a7ab4c319f3619b275f28c8fb87a"
+checksum = "9dd7e0c94051cda67123be68cf6b65211ba3dde7277be9068412de3e7ffd63ef"
 dependencies = [
  "bytes 1.1.0",
  "curve25519-dalek 3.2.0",
@@ -3181,10 +3370,10 @@ dependencies = [
  "lazy_static",
  "libp2p-core",
  "log",
- "prost",
+ "prost 0.9.0",
  "prost-build",
  "rand 0.8.5",
- "sha2 0.9.9",
+ "sha2 0.10.2",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -3193,33 +3382,34 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.31.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ef7b0ec5cf06530d9eb6cf59ae49d46a2c45663bde31c25a12f682664adbcf"
+checksum = "bf57a3c2e821331dda9fe612d4654d676ab6e33d18d9434a18cced72630df6ad"
 dependencies = [
  "futures 0.3.21",
+ "futures-timer",
+ "instant",
  "libp2p-core",
  "libp2p-swarm",
  "log",
  "rand 0.7.3",
  "void",
- "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba1a6ff33e4a274c89a3b1d78b9f34f32af13265cc5c46c16938262d4e945a"
+checksum = "962c0fb0e7212fb96a69b87f2d09bcefd317935239bdc79cda900e7a8897a3fe"
 dependencies = [
- "asynchronous-codec 0.6.0",
+ "asynchronous-codec",
  "bytes 1.1.0",
  "futures 0.3.21",
  "libp2p-core",
  "log",
- "prost",
+ "prost 0.9.0",
  "prost-build",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
  "void",
 ]
 
@@ -3239,89 +3429,96 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.4.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2852b61c90fa8ce3c8fcc2aba76e6cefc20d648f9df29157d6b3a916278ef3e3"
+checksum = "3aa754cb7bccef51ebc3c458c6bbcef89d83b578a9925438389be841527d408f"
 dependencies = [
- "asynchronous-codec 0.6.0",
+ "asynchronous-codec",
  "bytes 1.1.0",
+ "either",
  "futures 0.3.21",
  "futures-timer",
+ "instant",
  "libp2p-core",
  "libp2p-swarm",
  "log",
  "pin-project 1.0.10",
- "prost",
+ "prost 0.9.0",
  "prost-build",
- "rand 0.7.3",
+ "rand 0.8.5",
  "smallvec",
- "unsigned-varint 0.7.1",
+ "static_assertions",
+ "thiserror",
+ "unsigned-varint",
  "void",
- "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-rendezvous"
-version = "0.1.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a6d2b9e7677eff61dc3d2854876aaf3976d84a01ef6664b610c77a0c9407c5"
+checksum = "bbd0baab894c5b84da510b915d53264d566c3c35889f09931fe9edbd2a773bee"
 dependencies = [
- "asynchronous-codec 0.6.0",
+ "asynchronous-codec",
  "bimap",
  "futures 0.3.21",
+ "futures-timer",
+ "instant",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost",
+ "prost 0.9.0",
  "prost-build",
  "rand 0.8.5",
- "sha2 0.9.9",
+ "sha2 0.10.2",
  "thiserror",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
  "void",
- "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.13.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a877a4ced6d46bf84677e1974e8cf61fb434af73b2e96fb48d6cb6223a4634d8"
+checksum = "b5e6a6fc6c9ad95661f46989473b34bd2993d14a4de497ff3b2668a910d4b869"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
  "futures 0.3.21",
+ "instant",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "lru 0.7.5",
  "rand 0.7.3",
  "smallvec",
- "unsigned-varint 0.7.1",
- "wasm-timer",
+ "unsigned-varint",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.31.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5184a508f223bc100a12665517773fb8730e9f36fc09eefb670bf01b107ae9"
+checksum = "8f0c69ad9e8f7c5fc50ad5ad9c7c8b57f33716532a2b623197f69f93e374d14c"
 dependencies = [
  "either",
+ "fnv",
  "futures 0.3.21",
+ "futures-timer",
+ "instant",
  "libp2p-core",
  "log",
+ "pin-project 1.0.10",
  "rand 0.7.3",
  "smallvec",
+ "thiserror",
  "void",
- "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.25.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "072c290f727d39bdc4e9d6d1c847978693d25a673bd757813681e33e5f6c00c2"
+checksum = "4f693c8c68213034d472cbb93a379c63f4f307d97c06f1c41e4985de481687a5"
 dependencies = [
  "quote",
  "syn",
@@ -3329,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7399c5b6361ef525d41c11fcf51635724f832baf5819b30d3d873eabb4fbae4b"
+checksum = "193447aa729c85aac2376828df76d171c1a589c9e6b58fcc7f9d9a020734122c"
 dependencies = [
  "async-io",
  "futures 0.3.21",
@@ -3341,14 +3538,14 @@ dependencies = [
  "libc",
  "libp2p-core",
  "log",
- "socket2 0.4.4",
+ "socket2",
 ]
 
 [[package]]
 name = "libp2p-uds"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7563e46218165dfd60f64b96f7ce84590d75f53ecbdc74a7dd01450dc5973"
+checksum = "24bdab114f7f2701757d6541266e1131b429bbae382008f207f2114ee4222dcb"
 dependencies = [
  "async-std",
  "futures 0.3.21",
@@ -3358,9 +3555,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1008a302b73c5020251f9708c653f5ed08368e530e247cc9cd2f109ff30042cf"
+checksum = "4f6ea0f84a967ef59a16083f222c18115ae2e91db69809dce275df62e101b279"
 dependencies = [
  "futures 0.3.21",
  "js-sys",
@@ -3372,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.31.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e12df82d1ed64969371a9e65ea92b91064658604cc2576c2757f18ead9a1cf"
+checksum = "c932834c3754501c368d1bf3d0fb458487a642b90fc25df082a3a2f3d3b32e37"
 dependencies = [
  "either",
  "futures 0.3.21",
@@ -3390,13 +3587,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7362abb8867d7187e7e93df17f460d554c997fc5c8ac57dc1259057f6889af"
+checksum = "be902ebd89193cd020e89e89107726a38cfc0d16d18f613f4a37d046e92c7517"
 dependencies = [
  "futures 0.3.21",
  "libp2p-core",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "thiserror",
  "yamux",
 ]
@@ -3502,9 +3699,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.36"
+version = "0.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a261afc61b7a5e323933b402ca6a1765183687c614789b1e4db7762ed4230bca"
+checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
 
 [[package]]
 name = "lock_api"
@@ -3517,21 +3714,12 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
  "value-bag",
-]
-
-[[package]]
-name = "lru"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
-dependencies = [
- "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -3622,6 +3810,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memfd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6627dc657574b49d6ad27105ed671822be56e0d2547d413bfbf3e8d8fa92e7a"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmap2"
@@ -3768,27 +3965,27 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "multiaddr"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ee4ea82141951ac6379f964f71b20876d43712bea8faf6dd1a375e08a46499"
+checksum = "3c580bfdd8803cce319b047d239559a22f809094aaea4ac13902a1fdcfcd4261"
 dependencies = [
  "arrayref",
  "bs58",
  "byteorder",
  "data-encoding",
- "multihash 0.14.0",
+ "multihash",
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
  "url 2.2.2",
 ]
 
 [[package]]
 name = "multibase"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78c60039650ff12e140ae867ef5299a58e19dded4d334c849dc7177083667e2"
+checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
 dependencies = [
  "base-x",
  "data-encoding",
@@ -3797,39 +3994,26 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.13.2"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac63698b887d2d929306ea48b63760431ff8a24fac40ddb22f9c7f49fb7cab"
+checksum = "e3db354f401db558759dfc1e568d010a5d4146f4d3f637be1275ec4a3cf09689"
 dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "blake3",
- "digest 0.9.0",
- "generic-array 0.14.5",
+ "core2",
+ "digest 0.10.3",
  "multihash-derive",
- "sha2 0.9.9",
- "sha3 0.9.1",
- "unsigned-varint 0.5.1",
-]
-
-[[package]]
-name = "multihash"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
-dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.5",
- "multihash-derive",
- "sha2 0.9.9",
- "unsigned-varint 0.7.1",
+ "sha2 0.10.2",
+ "sha3 0.10.1",
+ "unsigned-varint",
 ]
 
 [[package]]
 name = "multihash-derive"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
+checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro-error",
@@ -3847,16 +4031,16 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multistream-select"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a336acba8bc87c8876f6425407dbbe6c417bf478b22015f8fb0994ef3bc0ab"
+checksum = "363a84be6453a70e63513660f4894ef815daf88e3356bffcda9ca27d810ce83b"
 dependencies = [
  "bytes 1.1.0",
  "futures 0.3.21",
  "log",
  "pin-project 1.0.10",
  "smallvec",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3909,6 +4093,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345b8ab5bd4e71a2986663e88c56856699d060e78e152e6e9d7966fcd5491297"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "libc",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733ea73609acfd7fa7ddadfb7bf709b0471668c456ad9513685af543a06342b2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25af9cf0dc55498b7bd94a1508af7a78706aa0ab715a73c5169273e03c84845e"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8785b8141e8432aa45fceb922a7e876d7da3fad37fa7e7ec702ace3aa0826b"
+dependencies = [
+ "bytes 1.1.0",
+ "futures 0.3.21",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "tokio",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4c9f9547a08241bee7b6558b9b98e1f290d187de8b7cfca2bbb4937bcaa8f8"
+dependencies = [
+ "async-io",
+ "bytes 1.1.0",
+ "futures 0.3.21",
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "nix"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3958,6 +4220,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
+dependencies = [
+ "arrayvec 0.4.12",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -4043,29 +4315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "open-metrics-client"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7337d80c23c2d8b1349563981bc4fb531220733743ba8115454a67b181173f0d"
-dependencies = [
- "dtoa",
- "itoa 0.4.8",
- "open-metrics-client-derive-text-encode",
- "owning_ref",
-]
-
-[[package]]
-name = "open-metrics-client-derive-text-encode"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c83b586f00268c619c1cb3340ec1a6f59dd9ba1d9833a273a68e6d5cd8ffc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4103,9 +4352,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "owning_ref"
@@ -4119,7 +4365,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4136,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4152,7 +4398,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4167,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4182,7 +4428,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-balances"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4201,7 +4446,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4218,7 +4462,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "encointer-primitives",
  "jsonrpc-core",
@@ -4237,7 +4480,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4248,9 +4490,9 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "encointer-ceremonies-assignment",
+ "encointer-meetup-validation",
  "encointer-primitives",
  "frame-benchmarking",
  "frame-support",
@@ -4272,7 +4514,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "encointer-primitives",
  "jsonrpc-core",
@@ -4291,7 +4532,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4302,7 +4542,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4321,7 +4560,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "encointer-primitives",
  "jsonrpc-core",
@@ -4340,7 +4578,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "encointer-primitives",
  "sp-api",
@@ -4350,7 +4587,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-scheduler"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#7e80f00386cfcf07c8aa2168aa1a57ec6c59b0bd"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4367,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4390,7 +4626,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4404,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4418,7 +4654,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4433,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4454,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4468,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4486,14 +4722,13 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "smallvec",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -4503,11 +4738,9 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
+ "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "sp-api",
@@ -4520,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4531,7 +4764,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4545,9 +4778,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d121a9af17a43efd0a38c6afa508b927ba07785bd4709efb2ac03bf77efef8d"
+checksum = "55a7901b85874402471e131de3332dde0e51f38432c69a3853627c8e25433048"
 dependencies = [
  "blake2-rfc",
  "crc32fast",
@@ -4595,20 +4828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 
 [[package]]
-name = "parity-tokio-ipc"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9981e32fb75e004cc148f5fb70342f393830e0a4aa62e3cc93b50976218d42b6"
-dependencies = [
- "futures 0.3.21",
- "libc",
- "log",
- "rand 0.7.3",
- "tokio",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "parity-util-mem"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4649,24 +4868,6 @@ name = "parity-wasm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
-
-[[package]]
-name = "parity-ws"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5983d3929ad50f12c3eb9a6743f19d691866ecd44da74c0a3308c3f8a56df0c6"
-dependencies = [
- "byteorder",
- "bytes 0.4.12",
- "httparse",
- "log",
- "mio 0.6.23",
- "mio-extras",
- "rand 0.7.3",
- "sha-1 0.8.2",
- "slab",
- "url 2.2.2",
-]
 
 [[package]]
 name = "parking"
@@ -4906,7 +5107,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
- "cpufeatures 0.2.1",
+ "cpufeatures",
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
@@ -4918,7 +5119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if 1.0.0",
- "cpufeatures 0.2.1",
+ "cpufeatures",
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
@@ -5009,13 +5210,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a896938cc6018c64f279888b8c7559d3725210d5db9a3a1ee6bc7188d51d34"
+dependencies = [
+ "dtoa",
+ "itoa 1.0.1",
+ "owning_ref",
+ "prometheus-client-derive-text-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-text-encode"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e12d01b9d66ad9eb4529c57666b6263fc1993cb30261d83ead658fdd932652"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes 1.1.0",
- "prost-derive",
+ "prost-derive 0.9.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+dependencies = [
+ "bytes 1.1.0",
+ "prost-derive 0.10.1",
 ]
 
 [[package]]
@@ -5031,7 +5265,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost",
+ "prost 0.9.0",
  "prost-types",
  "regex",
  "tempfile",
@@ -5052,13 +5286,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes 1.1.0",
- "prost",
+ "prost 0.9.0",
 ]
 
 [[package]]
@@ -5119,7 +5366,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -5200,6 +5447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5271,9 +5527,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.33"
+version = "0.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d808cff91dfca7b239d40b972ba628add94892b1d9e19a842aedc5cfae8ab1a"
+checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
 dependencies = [
  "log",
  "rustc-hash",
@@ -5344,6 +5600,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c31b5c4033f8fdde8700e4657be2c497e7288f01515be52168c631e2e4d4086"
 
 [[package]]
+name = "rfc6979"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+dependencies = [
+ "crypto-bigint",
+ "hmac 0.11.0",
+ "zeroize",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5379,6 +5646,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtnetlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f54290e54521dac3de4149d83ddf9f62a359b3cc93bcb494a794a41e6f4744b"
+dependencies = [
+ "async-global-executor",
+ "futures 0.3.21",
+ "log",
+ "netlink-packet-route",
+ "netlink-proto",
+ "nix",
+ "thiserror",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5407,15 +5689,6 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
@@ -5425,9 +5698,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.31.3"
+version = "0.33.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dcfc2778a90e38f56a708bfc90572422e11d6c7ee233d053d1f782cf9df6d2"
+checksum = "938a344304321a9da4973b9ff4f9f8db9caf4597dfd9dda6a60b523340a0fff0"
 dependencies = [
  "bitflags",
  "errno",
@@ -5439,11 +5712,10 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
 dependencies = [
- "base64",
  "log",
  "ring",
  "sct",
@@ -5452,14 +5724,23 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -5515,7 +5796,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "log",
  "sp-core",
@@ -5526,7 +5807,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "futures 0.3.21",
  "futures-timer",
@@ -5549,7 +5830,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5565,7 +5846,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2 0.5.3",
@@ -5582,7 +5863,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -5593,10 +5874,10 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "chrono",
- "clap 3.1.6",
+ "clap 3.1.18",
  "fdlimit",
  "futures 0.3.21",
  "hex",
@@ -5608,6 +5889,7 @@ dependencies = [
  "regex",
  "rpassword",
  "sc-client-api",
+ "sc-client-db",
  "sc-keystore",
  "sc-network",
  "sc-service",
@@ -5631,7 +5913,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "fnv",
  "futures 0.3.21",
@@ -5659,7 +5941,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -5684,7 +5966,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
@@ -5708,7 +5990,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
@@ -5737,7 +6019,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
@@ -5762,10 +6044,10 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "lazy_static",
- "lru 0.6.6",
+ "lru",
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "sc-executor-common",
@@ -5789,13 +6071,13 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "environmental",
  "parity-scale-codec",
  "sc-allocator",
- "sp-core",
  "sp-maybe-compressed-blob",
+ "sp-sandbox",
  "sp-serializer",
  "sp-wasm-interface",
  "thiserror",
@@ -5806,15 +6088,14 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "log",
  "parity-scale-codec",
  "sc-allocator",
  "sc-executor-common",
- "scoped-tls",
- "sp-core",
  "sp-runtime-interface",
+ "sp-sandbox",
  "sp-wasm-interface",
  "wasmi",
 ]
@@ -5822,7 +6103,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -5831,8 +6112,8 @@ dependencies = [
  "parity-wasm 0.42.2",
  "sc-allocator",
  "sc-executor-common",
- "sp-core",
  "sp-runtime-interface",
+ "sp-sandbox",
  "sp-wasm-interface",
  "wasmtime",
 ]
@@ -5840,7 +6121,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "ahash",
  "async-trait",
@@ -5880,7 +6161,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "ansi_term",
  "futures 0.3.21",
@@ -5897,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
  "hex",
@@ -5912,10 +6193,10 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
- "asynchronous-codec 0.5.0",
+ "asynchronous-codec",
  "bitflags",
  "bytes 1.1.0",
  "cid",
@@ -5930,16 +6211,19 @@ dependencies = [
  "linked-hash-map",
  "linked_hash_set",
  "log",
- "lru 0.7.5",
+ "lru",
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "pin-project 1.0.10",
- "prost",
+ "prost 0.10.4",
  "prost-build",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
+ "sc-network-common",
+ "sc-network-light",
+ "sc-network-sync",
  "sc-peerset",
  "sc-utils",
  "serde",
@@ -5953,22 +6237,35 @@ dependencies = [
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
- "unsigned-varint 0.6.0",
+ "unsigned-varint",
  "void",
  "zeroize",
 ]
 
 [[package]]
+name = "sc-network-common"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+dependencies = [
+ "futures 0.3.21",
+ "libp2p",
+ "parity-scale-codec",
+ "prost-build",
+ "sc-peerset",
+ "smallvec",
+]
+
+[[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "ahash",
  "futures 0.3.21",
  "futures-timer",
  "libp2p",
  "log",
- "lru 0.7.5",
+ "lru",
  "sc-network",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -5976,9 +6273,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-network-light"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+dependencies = [
+ "futures 0.3.21",
+ "libp2p",
+ "log",
+ "parity-scale-codec",
+ "prost 0.10.4",
+ "prost-build",
+ "sc-client-api",
+ "sc-network-common",
+ "sc-peerset",
+ "sp-blockchain",
+ "sp-core",
+ "sp-runtime",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-network-sync"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+dependencies = [
+ "bitflags",
+ "either",
+ "fork-tree",
+ "futures 0.3.21",
+ "libp2p",
+ "log",
+ "lru",
+ "parity-scale-codec",
+ "prost 0.10.4",
+ "prost-build",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-network-common",
+ "sc-peerset",
+ "smallvec",
+ "sp-arithmetic",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-finality-grandpa",
+ "sp-runtime",
+ "thiserror",
+]
+
+[[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -6006,7 +6352,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "futures 0.3.21",
  "libp2p",
@@ -6019,7 +6365,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -6028,12 +6374,11 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "futures 0.3.21",
  "hash-db",
- "jsonrpc-core",
- "jsonrpc-pubsub",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.0",
@@ -6059,18 +6404,16 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "futures 0.3.21",
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
- "jsonrpc-pubsub",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "sc-chain-spec",
  "sc-transaction-pool-api",
+ "scale-info",
  "serde",
  "serde_json",
  "sp-core",
@@ -6084,14 +6427,10 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "futures 0.3.21",
- "jsonrpc-core",
- "jsonrpc-http-server",
- "jsonrpc-ipc-server",
- "jsonrpc-pubsub",
- "jsonrpc-ws-server",
+ "jsonrpsee",
  "log",
  "serde_json",
  "substrate-prometheus-endpoint",
@@ -6101,7 +6440,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
  "directories",
@@ -6109,8 +6448,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "hash-db",
- "jsonrpc-core",
- "jsonrpc-pubsub",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parity-util-mem",
@@ -6126,9 +6464,11 @@ dependencies = [
  "sc-informant",
  "sc-keystore",
  "sc-network",
+ "sc-network-common",
  "sc-offchain",
  "sc-rpc",
  "sc-rpc-server",
+ "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
  "sc-transaction-pool",
@@ -6165,7 +6505,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6177,9 +6517,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-sysinfo"
+version = "6.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+dependencies = [
+ "futures 0.3.21",
+ "libc",
+ "log",
+ "rand 0.7.3",
+ "rand_pcg 0.2.1",
+ "regex",
+ "sc-telemetry",
+ "serde",
+ "serde_json",
+ "sp-core",
+ "sp-io",
+ "sp-std",
+]
+
+[[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "chrono",
  "futures 0.3.21",
@@ -6197,7 +6556,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "ansi_term",
  "atty",
@@ -6228,7 +6587,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -6239,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "futures 0.3.21",
  "futures-timer",
@@ -6266,7 +6625,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "futures 0.3.21",
  "log",
@@ -6279,7 +6638,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "futures 0.3.21",
  "futures-timer",
@@ -6291,9 +6650,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0563970d79bcbf3c537ce3ad36d859b30d36fc5b190efd227f1f7a84d7cf0d42"
+checksum = "c46be926081c9f4dd5dd9b6f1d3e3229f2360bc6502dd8836f84a93b7c75e99a"
 dependencies = [
  "bitvec",
  "cfg-if 1.0.0",
@@ -6305,9 +6664,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.0.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7805950c36512db9e3251c970bb7ac425f326716941862205d612ab3b5e46e2"
+checksum = "50e334bb10a245e28e5fd755cabcafd96cfcd167c99ae63a46924ca8d8703a3c"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -6344,12 +6703,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6357,12 +6710,24 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+dependencies = [
+ "der",
+ "generic-array 0.14.5",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -6421,7 +6786,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 dependencies = [
- "semver-parser 0.7.0",
+ "semver-parser",
 ]
 
 [[package]]
@@ -6430,16 +6795,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
 
 [[package]]
@@ -6456,15 +6812,6 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -6526,7 +6873,7 @@ checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures 0.2.1",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -6551,7 +6898,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures 0.2.1",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -6563,7 +6910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if 1.0.0",
- "cpufeatures 0.2.1",
+ "cpufeatures",
  "digest 0.10.3",
 ]
 
@@ -6605,6 +6952,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6618,6 +6975,10 @@ name = "signature"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+dependencies = [
+ "digest 0.9.0",
+ "rand_core 0.6.3",
+]
 
 [[package]]
 name = "simba"
@@ -6651,31 +7012,19 @@ checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "snow"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6142f7c25e94f6fd25a32c3348ec230df9109b463f59c8c7acc4bd34936babb7"
+checksum = "774d05a3edae07ce6d68ea6984f3c05e9bba8927e3dd591e3b479e5b03213d0d"
 dependencies = [
  "aes-gcm",
- "blake2 0.9.2",
+ "blake2",
  "chacha20poly1305",
- "rand 0.8.5",
+ "curve25519-dalek 4.0.0-pre.1",
  "rand_core 0.6.3",
  "ring",
- "rustc_version 0.3.3",
- "sha2 0.9.9",
+ "rustc_version 0.4.0",
+ "sha2 0.10.2",
  "subtle",
- "x25519-dalek",
-]
-
-[[package]]
-name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6707,7 +7056,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "hash-db",
  "log",
@@ -6724,9 +7073,9 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "blake2 0.10.4",
+ "blake2",
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
@@ -6736,7 +7085,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6749,7 +7098,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6764,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6776,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6788,11 +7137,11 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "futures 0.3.21",
  "log",
- "lru 0.7.5",
+ "lru",
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "sp-api",
@@ -6806,7 +7155,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
@@ -6825,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6843,7 +7192,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6857,7 +7206,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "base58",
  "bitflags",
@@ -6903,9 +7252,9 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "blake2 0.10.4",
+ "blake2",
  "byteorder",
  "digest 0.10.3",
  "sha2 0.10.2",
@@ -6917,7 +7266,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6928,7 +7277,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.0",
@@ -6937,7 +7286,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6947,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6958,7 +7307,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6976,7 +7325,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -6990,7 +7339,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "futures 0.3.21",
  "hash-db",
@@ -7015,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7026,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
@@ -7043,7 +7392,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "thiserror",
  "zstd",
@@ -7052,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7062,7 +7411,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -7072,7 +7421,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -7082,7 +7431,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7104,7 +7453,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7121,7 +7470,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.1.3",
@@ -7131,9 +7480,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-sandbox"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+dependencies = [
+ "log",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-io",
+ "sp-std",
+ "sp-wasm-interface",
+ "wasmi",
+]
+
+[[package]]
 name = "sp-serializer"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "serde",
  "serde_json",
@@ -7142,7 +7505,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7156,7 +7519,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7167,7 +7530,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "hash-db",
  "log",
@@ -7189,12 +7552,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7207,7 +7570,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "log",
  "sp-core",
@@ -7220,7 +7583,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -7236,7 +7599,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -7248,7 +7611,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -7257,7 +7620,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
  "log",
@@ -7273,7 +7636,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7289,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7306,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -7317,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -7335,11 +7698,12 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "ss58-registry"
-version = "1.15.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9799e6d412271cb2414597581128b03f3285f260ea49f5363d07df6a332b3e"
+checksum = "5e1e7c268f5610088463d23188fc9e764cda491784360e5e4ea3a8ce1e0e2ac9"
 dependencies = [
  "Inflector",
+ "num-format",
  "proc-macro2",
  "quote",
  "serde",
@@ -7487,18 +7851,17 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.21",
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-rpc-api",
  "sc-transaction-pool-api",
+ "serde_json",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
@@ -7509,7 +7872,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "futures-util",
  "hyper",
@@ -7522,7 +7885,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#8cbda809d3495f38ce04eec46e90330db213af8a"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -7562,6 +7925,27 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75182f12f490e953596550b65ee31bda7c8e043d9386174b353bda50838c3fd"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -7633,6 +8017,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"
@@ -7723,30 +8113,31 @@ dependencies = [
  "parking_lot 0.12.0",
  "pin-project-lite 0.2.8",
  "signal-hook-registry",
- "socket2 0.4.4",
+ "socket2",
+ "tokio-macros",
  "winapi 0.3.9",
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.22.0"
+name = "tokio-macros"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls",
  "tokio",
  "webpki",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
-dependencies = [
- "futures-core",
- "pin-project-lite 0.2.8",
- "tokio",
 ]
 
 [[package]]
@@ -7759,6 +8150,20 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
+ "pin-project-lite 0.2.8",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
  "pin-project-lite 0.2.8",
  "tokio",
 ]
@@ -7823,12 +8228,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
+ "ahash",
  "lazy_static",
  "log",
+ "lru",
  "tracing-core",
 ]
 
@@ -7889,9 +8296,9 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.20.4"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca94d4e9feb6a181c690c4040d7a24ef34018d8313ac5044a61d21222ae24e31"
+checksum = "9c31f240f59877c3d4bb3b3ea0ec5a6a0cff07323580ff8c7a605cd7d08b255d"
 dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
@@ -7913,9 +8320,9 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.20.4"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecae383baad9995efaa34ce8e57d12c3f305e545887472a492b838f4b5cfb77a"
+checksum = "e4ba72c2ea84515690c9fcef4c6c660bb9df3036ed1051686de84605b74fd558"
 dependencies = [
  "cfg-if 1.0.0",
  "futures-util",
@@ -7923,7 +8330,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-cache",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "resolv-conf",
  "smallvec",
  "thiserror",
@@ -8041,29 +8448,11 @@ dependencies = [
 
 [[package]]
 name = "unsigned-varint"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
-dependencies = [
- "asynchronous-codec 0.5.0",
- "bytes 1.1.0",
- "futures-io",
- "futures-util",
-]
-
-[[package]]
-name = "unsigned-varint"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 dependencies = [
- "asynchronous-codec 0.6.0",
+ "asynchronous-codec",
  "bytes 1.1.0",
  "futures-io",
  "futures-util",
@@ -8106,9 +8495,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
 dependencies = [
  "ctor",
  "version_check",
@@ -8286,6 +8675,7 @@ checksum = "ca00c5147c319a8ec91ec1a0edbec31e566ce2c9cc93b3f9bb86a9efd0eb795d"
 dependencies = [
  "downcast-rs",
  "libc",
+ "libm",
  "memory_units",
  "num-rational 0.2.4",
  "num-traits",
@@ -8304,31 +8694,30 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.81.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98930446519f63d00a836efdc22f67766ceae8dbcc1571379f2bcabc6b2b9abc"
+checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wasmtime"
-version = "0.33.1"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9c724da92e39a85d2231d4c2a942c8be295211441dbca581c6c3f3f45a9f00"
+checksum = "21ffb4705016d5ca91e18a72ed6822dab50e6d5ddd7045461b17ef19071cdef1"
 dependencies = [
  "anyhow",
  "backtrace",
  "bincode",
  "cfg-if 1.0.0",
- "cpp_demangle",
  "indexmap",
  "lazy_static",
  "libc",
  "log",
  "object",
+ "once_cell",
  "paste",
  "psm",
  "rayon",
  "region",
- "rustc-demangle",
  "serde",
  "target-lexicon",
  "wasmparser",
@@ -8342,9 +8731,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.33.1"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4439d99100298344567c0eb6916ad5864e99e54760b8177c427e529077fb30"
+checksum = "85c6ab24291fa7cb3a181f5669f6c72599b7ef781669759b45c7828c5999d0c0"
 dependencies = [
  "anyhow",
  "base64",
@@ -8362,9 +8751,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.33.1"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1762765dd69245f00e5d9783b695039e449a7be0f9c5383e4c78465dd6131aeb"
+checksum = "f04c810078a491b7bc4866ebe045f714d2b95e6b539e1f64009a4a7606be11de"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -8384,9 +8773,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.33.1"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4468301d95ec71710bb6261382efe27d1296447711645e3dbabaea6e4de3504"
+checksum = "61448266ea164b1ac406363cdcfac81c7c44db4d94c7a81c8620ac6c5c6cdf59"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -8404,41 +8793,56 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.33.1"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0ae6e581ff014b470ec35847ea3c0b4c3ace89a55df5a04c802a11f4574e7d"
+checksum = "156b4623c6b0d4b8c24afb846c20525922f538ef464cc024abab7ea8de2109a2"
 dependencies = [
  "addr2line",
  "anyhow",
  "bincode",
  "cfg-if 1.0.0",
+ "cpp_demangle",
  "gimli",
+ "log",
  "object",
  "region",
+ "rustc-demangle",
  "rustix",
  "serde",
  "target-lexicon",
  "thiserror",
  "wasmtime-environ",
+ "wasmtime-jit-debug",
  "wasmtime-runtime",
  "winapi 0.3.9",
 ]
 
 [[package]]
-name = "wasmtime-runtime"
-version = "0.33.1"
+name = "wasmtime-jit-debug"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9c28877ae37a367cda7b52b8887589816152e95dde9b7c80cc686f52761961"
+checksum = "d5dc31f811760a6c76b2672c404866fd19b75e5fb3b0075a3e377a6846490654"
+dependencies = [
+ "lazy_static",
+ "object",
+ "rustix",
+]
+
+[[package]]
+name = "wasmtime-runtime"
+version = "0.35.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f907beaff69d4d920fa4688411ee4cc75c0f01859e424677f9e426e2ef749864"
 dependencies = [
  "anyhow",
  "backtrace",
  "cc",
  "cfg-if 1.0.0",
  "indexmap",
- "lazy_static",
  "libc",
  "log",
  "mach",
+ "memfd",
  "memoffset",
  "more-asserts",
  "rand 0.8.5",
@@ -8446,14 +8850,15 @@ dependencies = [
  "rustix",
  "thiserror",
  "wasmtime-environ",
+ "wasmtime-jit-debug",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "wasmtime-types"
-version = "0.33.1"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395726e8f5dd8c57cb0db445627b842343f7e29ed7489467fdf7953ed9d3cd4f"
+checksum = "514ef0e5fd197b9609dc9eb74beba0c84d5a12b2417cbae55534633329ba4852"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -8473,9 +8878,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
@@ -8483,9 +8888,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.21.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
  "webpki",
 ]
@@ -8512,9 +8917,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
+checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "winapi"
@@ -8560,17 +8965,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac7fef12f4b59cd0a29339406cc9203ab44e440ddff6b3f5a41455349fa9cf3"
+dependencies = [
+ "windows_aarch64_msvc 0.29.0",
+ "windows_i686_gnu 0.29.0",
+ "windows_i686_msvc 0.29.0",
+ "windows_x86_64_gnu 0.29.0",
+ "windows_x86_64_msvc 0.29.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
 ]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d027175d00b01e0cbeb97d6ab6ebe03b12330a35786cbaca5252b1c4bf5d9b"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -8580,9 +9004,21 @@ checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8793f59f7b8e8b01eda1a652b2697d87b93097198ae85f823b969ca5b89bba58"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8602f6c418b67024be2996c512f5f995de3ba417f4c75af68401ab8756796ae4"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8592,9 +9028,21 @@ checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d615f419543e0bd7d2b3323af0d86ff19cbc4f816e6453f36a2c2ce889c354"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d95421d9ed3672c280884da53201a5c46b7b2765ca6faf34b0d71cf34a3561"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8604,9 +9052,9 @@ checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -8662,23 +9110,23 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d9028f208dd5e63c614be69f115c1b53cacc1111437d4c765185856666c107"
+checksum = "0c0608f53c1dc0bad505d03a34bbd49fbf2ad7b51eb036123e896365532745a1"
 dependencies = [
  "futures 0.3.21",
  "log",
  "nohash-hasher",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "rand 0.8.5",
  "static_assertions",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.5.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb5728b8afd3f280a869ce1d4c554ffaed35f45c231fc41bfbd0381bef50317"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
 dependencies = [
  "zeroize_derive",
 ]
@@ -8697,18 +9145,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.9.2+zstd.1.5.1"
+version = "0.10.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2390ea1bf6c038c39674f22d95f0564725fc06034a47129179810b2fc58caa54"
+checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.3+zstd.1.5.1"
+version = "4.1.6+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99d81b99fb3c2c2c794e3fe56c305c63d5173a16a46b5850b07c935ffc7db79"
+checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -8716,9 +9164,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.2+zstd.1.5.1"
+version = "1.6.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2daf2f248d9ea44454bfcb2516534e8b8ad2fc91bf818a1885495fc42bc8ac9f"
+checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.1.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=master#edf0c13b05e43d9550a0a3773915c7bee74a48b5"
+source = "git+https://github.com/scs/substrate-api-client?branch=cl/better-generics#d0245699b49ebc6b7a59673cd54c7ec80af8f1a2"
 dependencies = [
  "ac-primitives",
  "log",
@@ -27,7 +27,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.1.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=master#edf0c13b05e43d9550a0a3773915c7bee74a48b5"
+source = "git+https://github.com/scs/substrate-api-client?branch=cl/better-generics#d0245699b49ebc6b7a59673cd54c7ec80af8f1a2"
 dependencies = [
  "ac-primitives",
  "frame-metadata",
@@ -47,7 +47,7 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.1.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=master#edf0c13b05e43d9550a0a3773915c7bee74a48b5"
+source = "git+https://github.com/scs/substrate-api-client?branch=cl/better-generics#d0245699b49ebc6b7a59673cd54c7ec80af8f1a2"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7046,7 +7046,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -7154,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "base58",
  "bitflags",
@@ -7200,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "blake2",
  "byteorder",
@@ -7234,7 +7234,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7287,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "futures",
  "hash-db",
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "async-trait",
  "futures",
@@ -7359,7 +7359,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -7379,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7401,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7418,7 +7418,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7478,7 +7478,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "hash-db",
  "log",
@@ -7500,12 +7500,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7547,7 +7547,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -7584,7 +7584,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7628,7 +7628,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#699375ef8dd0cb19f0b5d8917e4e2a02d50c92bf"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -7721,7 +7721,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.6.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=master#edf0c13b05e43d9550a0a3773915c7bee74a48b5"
+source = "git+https://github.com/scs/substrate-api-client?branch=cl/better-generics#d0245699b49ebc6b7a59673cd54c7ec80af8f1a2"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -7772,7 +7772,7 @@ dependencies = [
 [[package]]
 name = "substrate-client-keystore"
 version = "0.6.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=master#edf0c13b05e43d9550a0a3773915c7bee74a48b5"
+source = "git+https://github.com/scs/substrate-api-client?branch=cl/better-generics#d0245699b49ebc6b7a59673cd54c7ec80af8f1a2"
 dependencies = [
  "async-trait",
  "hex",
@@ -8328,7 +8328,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,6 +1483,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1498,6 +1499,7 @@ dependencies = [
 [[package]]
 name = "encointer-ceremonies-assignment"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -1532,15 +1534,6 @@ dependencies = [
  "sp-runtime",
  "substrate-api-client",
  "substrate-client-keystore",
-]
-
-[[package]]
-name = "encointer-meetup-validation"
-version = "1.0.0"
-dependencies = [
- "encointer-primitives",
- "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -1640,6 +1633,7 @@ dependencies = [
 [[package]]
 name = "encointer-primitives"
 version = "1.1.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "bs58",
  "concat-arrays",
@@ -1690,6 +1684,7 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 [[package]]
 name = "ep-core"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -4428,6 +4423,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-balances"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4446,6 +4442,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar"
 version = "1.1.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4462,6 +4459,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "jsonrpc-core",
@@ -4480,6 +4478,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4490,9 +4489,9 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies"
 version = "1.1.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-ceremonies-assignment",
- "encointer-meetup-validation",
  "encointer-primitives",
  "frame-benchmarking",
  "frame-support",
@@ -4514,6 +4513,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "jsonrpc-core",
@@ -4532,6 +4532,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4542,6 +4543,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities"
 version = "1.1.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4560,6 +4562,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "jsonrpc-core",
@@ -4578,6 +4581,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
 version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "sp-api",
@@ -4587,6 +4591,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-scheduler"
 version = "1.1.0"
+source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,12 +918,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,10 +1275,8 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
  "syn",
 ]
 
@@ -1483,7 +1475,6 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1499,7 +1490,6 @@ dependencies = [
 [[package]]
 name = "encointer-ceremonies-assignment"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -1544,8 +1534,10 @@ dependencies = [
  "encointer-node-notee-runtime",
  "frame-benchmarking",
  "frame-benchmarking-cli",
- "jsonrpc-core",
+ "frame-system",
+ "jsonrpsee",
  "log",
+ "pallet-asset-tx-payment",
  "pallet-encointer-bazaar-rpc",
  "pallet-encointer-bazaar-rpc-runtime-api",
  "pallet-encointer-ceremonies-rpc",
@@ -1567,6 +1559,7 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
+ "serde_json",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
@@ -1574,10 +1567,13 @@ dependencies = [
  "sp-consensus-aura",
  "sp-core",
  "sp-finality-grandpa",
+ "sp-inherents",
+ "sp-keyring",
  "sp-runtime",
  "sp-timestamp",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
+ "try-runtime-cli",
 ]
 
 [[package]]
@@ -1633,7 +1629,6 @@ dependencies = [
 [[package]]
 name = "encointer-primitives"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "bs58",
  "concat-arrays",
@@ -1648,6 +1643,14 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+]
+
+[[package]]
+name = "encointer-rpc"
+version = "0.1.0"
+dependencies = [
+ "jsonrpsee",
+ "thiserror",
 ]
 
 [[package]]
@@ -1684,7 +1687,6 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 [[package]]
 name = "ep-core"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -1729,7 +1731,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.21",
+ "futures",
 ]
 
 [[package]]
@@ -1789,7 +1791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9def033d8505edf199f6a5d07aa7e6d2d6185b164293b77f0efd108f4f3e11d"
 dependencies = [
  "either",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "log",
  "num-traits",
@@ -1865,7 +1867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2016,7 +2018,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-support-procedural-tools-derive",
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -2122,12 +2124,6 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "futures"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
@@ -2239,7 +2235,6 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -2610,17 +2605,6 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
@@ -2649,7 +2633,7 @@ dependencies = [
  "async-io",
  "core-foundation",
  "fnv",
- "futures 0.3.21",
+ "futures",
  "if-addrs",
  "ipnet",
  "log",
@@ -2795,74 +2779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-client-transports"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b99d4207e2a04fb4581746903c2bb7eb376f88de9c699d0f3e10feeac0cd3a"
-dependencies = [
- "derive_more",
- "futures 0.3.21",
- "jsonrpc-core",
- "jsonrpc-pubsub",
- "log",
- "serde",
- "serde_json",
- "url 1.7.2",
-]
-
-[[package]]
-name = "jsonrpc-core"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
-dependencies = [
- "futures 0.3.21",
- "futures-executor",
- "futures-util",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "jsonrpc-core-client"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51da17abecbdab3e3d4f26b01c5ec075e88d3abe3ab3b05dc9aa69392764ec0"
-dependencies = [
- "futures 0.3.21",
- "jsonrpc-client-transports",
-]
-
-[[package]]
-name = "jsonrpc-derive"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
-dependencies = [
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "jsonrpc-pubsub"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240f87695e6c6f62fb37f05c02c04953cf68d6408b8c1c89de85c7a0125b1011"
-dependencies = [
- "futures 0.3.21",
- "jsonrpc-core",
- "lazy_static",
- "log",
- "parking_lot 0.11.2",
- "rand 0.7.3",
- "serde",
-]
-
-[[package]]
 name = "jsonrpsee"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2872,8 +2788,30 @@ dependencies = [
  "jsonrpsee-http-server",
  "jsonrpsee-proc-macros",
  "jsonrpsee-types",
+ "jsonrpsee-ws-client",
  "jsonrpsee-ws-server",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d682f4a55081a2be3e639280c640523070e4aeb8ee2fd8dd9168fdae57a9db"
+dependencies = [
+ "futures-util",
+ "http",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "pin-project 1.0.10",
+ "rustls-native-certs",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util 0.7.2",
+ "tracing",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2884,9 +2822,11 @@ checksum = "6e27462b21279edf9a6a91f46ffbe125e9cdc58b901d2e08bf59b31a47d7d0ab"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.2",
+ "async-lock",
  "async-trait",
  "beef",
  "futures-channel",
+ "futures-timer",
  "futures-util",
  "hyper",
  "jsonrpsee-types",
@@ -2926,7 +2866,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b8d7f449cab3b747f12c3efc27f5cad537f3b597c6a3838b0fac628f4bf730a"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -2944,6 +2884,17 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f15180afb3761c7a3a32c0a8b680788176dcfdfe725b24c1758c90b1d1595b"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -3091,7 +3042,7 @@ checksum = "475ce2ac4a9727e53a519f6ee05b38abfcba8f0d39c4d24f103d184e36fd5b0f"
 dependencies = [
  "atomic",
  "bytes 1.1.0",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "getrandom 0.2.5",
  "instant",
@@ -3135,7 +3086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13b690e65046af6a09c0b27bd9508fa1cab0efce889de74b0b643b9d2a98f9a"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -3158,7 +3109,7 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "instant",
  "lazy_static",
@@ -3189,7 +3140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1d37f042f748e224f04785d0e987ae09a2aa518d6401d82d412dad83e360ed"
 dependencies = [
  "flate2",
- "futures 0.3.21",
+ "futures",
  "libp2p-core",
 ]
 
@@ -3200,7 +3151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "066e33e854e10b5c93fc650458bf2179c7e0d143db260b0963e44a94859817f1"
 dependencies = [
  "async-std-resolver",
- "futures 0.3.21",
+ "futures",
  "libp2p-core",
  "log",
  "smallvec",
@@ -3215,7 +3166,7 @@ checksum = "733d3ea6ebe7a7a85df2bc86678b93f24b015fae5fe3b3acc4c400e795a55d2d"
 dependencies = [
  "cuckoofilter",
  "fnv",
- "futures 0.3.21",
+ "futures",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3236,7 +3187,7 @@ dependencies = [
  "byteorder",
  "bytes 1.1.0",
  "fnv",
- "futures 0.3.21",
+ "futures",
  "hex_fmt",
  "instant",
  "libp2p-core",
@@ -3259,7 +3210,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5ef5a5b57904c7c33d6713ef918d239dc6b7553458f3475d87f8a18e9c651c8"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "libp2p-core",
  "libp2p-swarm",
@@ -3281,7 +3232,7 @@ dependencies = [
  "bytes 1.1.0",
  "either",
  "fnv",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -3307,7 +3258,7 @@ dependencies = [
  "async-io",
  "data-encoding",
  "dns-parser",
- "futures 0.3.21",
+ "futures",
  "if-watch",
  "lazy_static",
  "libp2p-core",
@@ -3343,7 +3294,7 @@ checksum = "442eb0c9fff0bf22a34f015724b4143ce01877e079ed0963c722d94c07c72160"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.1.0",
- "futures 0.3.21",
+ "futures",
  "libp2p-core",
  "log",
  "nohash-hasher",
@@ -3361,7 +3312,7 @@ checksum = "9dd7e0c94051cda67123be68cf6b65211ba3dde7277be9068412de3e7ffd63ef"
 dependencies = [
  "bytes 1.1.0",
  "curve25519-dalek 3.2.0",
- "futures 0.3.21",
+ "futures",
  "lazy_static",
  "libp2p-core",
  "log",
@@ -3381,7 +3332,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf57a3c2e821331dda9fe612d4654d676ab6e33d18d9434a18cced72630df6ad"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -3399,7 +3350,7 @@ checksum = "962c0fb0e7212fb96a69b87f2d09bcefd317935239bdc79cda900e7a8897a3fe"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.1.0",
- "futures 0.3.21",
+ "futures",
  "libp2p-core",
  "log",
  "prost 0.9.0",
@@ -3414,7 +3365,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f1a458bbda880107b5b36fcb9b5a1ef0c329685da0e203ed692a8ebe64cc92c"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "log",
  "pin-project 1.0.10",
  "rand 0.7.3",
@@ -3431,7 +3382,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes 1.1.0",
  "either",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -3456,7 +3407,7 @@ checksum = "bbd0baab894c5b84da510b915d53264d566c3c35889f09931fe9edbd2a773bee"
 dependencies = [
  "asynchronous-codec",
  "bimap",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -3479,7 +3430,7 @@ checksum = "b5e6a6fc6c9ad95661f46989473b34bd2993d14a4de497ff3b2668a910d4b869"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
- "futures 0.3.21",
+ "futures",
  "instant",
  "libp2p-core",
  "libp2p-swarm",
@@ -3497,7 +3448,7 @@ checksum = "8f0c69ad9e8f7c5fc50ad5ad9c7c8b57f33716532a2b623197f69f93e374d14c"
 dependencies = [
  "either",
  "fnv",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -3526,7 +3477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193447aa729c85aac2376828df76d171c1a589c9e6b58fcc7f9d9a020734122c"
 dependencies = [
  "async-io",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "if-watch",
  "ipnet",
@@ -3543,7 +3494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24bdab114f7f2701757d6541266e1131b429bbae382008f207f2114ee4222dcb"
 dependencies = [
  "async-std",
- "futures 0.3.21",
+ "futures",
  "libp2p-core",
  "log",
 ]
@@ -3554,7 +3505,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f6ea0f84a967ef59a16083f222c18115ae2e91db69809dce275df62e101b279"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "js-sys",
  "libp2p-core",
  "parity-send-wrapper",
@@ -3569,14 +3520,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c932834c3754501c368d1bf3d0fb458487a642b90fc25df082a3a2f3d3b32e37"
 dependencies = [
  "either",
- "futures 0.3.21",
+ "futures",
  "futures-rustls",
  "libp2p-core",
  "log",
  "quicksink",
  "rw-stream-sink",
  "soketto",
- "url 2.2.2",
+ "url",
  "webpki-roots",
 ]
 
@@ -3586,7 +3537,7 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be902ebd89193cd020e89e89107726a38cfc0d16d18f613f4a37d046e92c7517"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "libp2p-core",
  "parking_lot 0.12.0",
  "thiserror",
@@ -3969,11 +3920,11 @@ dependencies = [
  "byteorder",
  "data-encoding",
  "multihash",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "serde",
  "static_assertions",
  "unsigned-varint",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -4010,7 +3961,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -4031,7 +3982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "363a84be6453a70e63513660f4894ef815daf88e3356bffcda9ca27d810ce83b"
 dependencies = [
  "bytes 1.1.0",
- "futures 0.3.21",
+ "futures",
  "log",
  "pin-project 1.0.10",
  "smallvec",
@@ -4132,7 +4083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8785b8141e8432aa45fceb922a7e876d7da3fad37fa7e7ec702ace3aa0826b"
 dependencies = [
  "bytes 1.1.0",
- "futures 0.3.21",
+ "futures",
  "log",
  "netlink-packet-core",
  "netlink-sys",
@@ -4147,7 +4098,7 @@ checksum = "3e4c9f9547a08241bee7b6558b9b98e1f290d187de8b7cfca2bbb4937bcaa8f8"
 dependencies = [
  "async-io",
  "bytes 1.1.0",
- "futures 0.3.21",
+ "futures",
  "libc",
  "log",
 ]
@@ -4423,7 +4374,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-balances"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4442,7 +4392,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4459,12 +4408,10 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
+ "encointer-rpc",
+ "jsonrpsee",
  "log",
  "pallet-encointer-bazaar-rpc-runtime-api",
  "parking_lot 0.12.0",
@@ -4473,12 +4420,12 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
+ "thiserror",
 ]
 
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4489,7 +4436,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-primitives",
@@ -4513,12 +4459,10 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
+ "encointer-rpc",
+ "jsonrpsee",
  "log",
  "pallet-encointer-ceremonies-rpc-runtime-api",
  "parking_lot 0.12.0",
@@ -4527,12 +4471,12 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
+ "thiserror",
 ]
 
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4543,7 +4487,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4562,12 +4505,10 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
+ "encointer-rpc",
+ "jsonrpsee",
  "log",
  "pallet-encointer-communities-rpc-runtime-api",
  "parking_lot 0.12.0",
@@ -4576,12 +4517,12 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
+ "thiserror",
 ]
 
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "sp-api",
@@ -4591,7 +4532,6 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-scheduler"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#c365c5b4107bbe7b75f6f0316210ac5529dc6bba"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4820,7 +4760,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6e626dc84025ff56bf1476ed0e30d10c84d7f89a475ef46ebabee1095a8fba"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -4957,12 +4897,6 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -5146,15 +5080,6 @@ dependencies = [
  "impl-serde",
  "scale-info",
  "uint",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
 ]
 
 [[package]]
@@ -5580,6 +5505,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "remote-externalities"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+dependencies = [
+ "env_logger",
+ "jsonrpsee",
+ "log",
+ "parity-scale-codec",
+ "serde",
+ "serde_json",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-version",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5657,7 +5599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f54290e54521dac3de4149d83ddf9f62a359b3cc93bcb494a794a41e6f4744b"
 dependencies = [
  "async-global-executor",
- "futures 0.3.21",
+ "futures",
  "log",
  "netlink-packet-route",
  "netlink-proto",
@@ -5760,7 +5702,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "pin-project 0.4.29",
  "static_assertions",
 ]
@@ -5814,7 +5756,7 @@ name = "sc-basic-authorship"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -5870,7 +5812,7 @@ name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -5884,7 +5826,7 @@ dependencies = [
  "chrono",
  "clap 3.1.18",
  "fdlimit",
- "futures 0.3.21",
+ "futures",
  "hex",
  "libp2p",
  "log",
@@ -5921,7 +5863,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "fnv",
- "futures 0.3.21",
+ "futures",
  "hash-db",
  "log",
  "parity-scale-codec",
@@ -5974,7 +5916,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "libp2p",
  "log",
@@ -5998,7 +5940,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
+ "futures",
  "log",
  "parity-scale-codec",
  "sc-block-builder",
@@ -6027,7 +5969,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -6133,7 +6075,7 @@ dependencies = [
  "dyn-clone",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "hex",
  "log",
@@ -6169,7 +6111,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "ansi_term",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "log",
  "parity-util-mem",
@@ -6208,7 +6150,7 @@ dependencies = [
  "either",
  "fnv",
  "fork-tree",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "hex",
  "ip_network",
@@ -6252,7 +6194,7 @@ name = "sc-network-common"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "libp2p",
  "parity-scale-codec",
  "prost-build",
@@ -6266,7 +6208,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "ahash",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "libp2p",
  "log",
@@ -6282,7 +6224,7 @@ name = "sc-network-light"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "libp2p",
  "log",
  "parity-scale-codec",
@@ -6305,7 +6247,7 @@ dependencies = [
  "bitflags",
  "either",
  "fork-tree",
- "futures 0.3.21",
+ "futures",
  "libp2p",
  "log",
  "lru",
@@ -6333,7 +6275,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf492
 dependencies = [
  "bytes 1.1.0",
  "fnv",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "hex",
  "hyper",
@@ -6359,7 +6301,7 @@ name = "sc-peerset"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "libp2p",
  "log",
  "sc-utils",
@@ -6381,7 +6323,7 @@ name = "sc-rpc"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "hash-db",
  "jsonrpsee",
  "log",
@@ -6411,7 +6353,7 @@ name = "sc-rpc-api"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -6434,7 +6376,7 @@ name = "sc-rpc-server"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "jsonrpsee",
  "log",
  "serde_json",
@@ -6450,7 +6392,7 @@ dependencies = [
  "async-trait",
  "directories",
  "exit-future",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "hash-db",
  "jsonrpsee",
@@ -6526,7 +6468,7 @@ name = "sc-sysinfo"
 version = "6.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "libc",
  "log",
  "rand 0.7.3",
@@ -6546,7 +6488,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "chrono",
- "futures 0.3.21",
+ "futures",
  "libp2p",
  "log",
  "parking_lot 0.12.0",
@@ -6594,7 +6536,7 @@ name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -6605,7 +6547,7 @@ name = "sc-transaction-pool"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "linked-hash-map",
  "log",
@@ -6632,7 +6574,7 @@ name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "log",
  "serde",
  "sp-blockchain",
@@ -6645,7 +6587,7 @@ name = "sc-utils"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "lazy_static",
  "log",
@@ -6673,7 +6615,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e334bb10a245e28e5fd755cabcafd96cfcd167c99ae63a46924ca8d8703a3c"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -6840,9 +6782,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -7051,7 +6993,7 @@ dependencies = [
  "base64",
  "bytes 1.1.0",
  "flate2",
- "futures 0.3.21",
+ "futures",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -7081,7 +7023,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "blake2",
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -7144,7 +7086,7 @@ name = "sp-blockchain"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "log",
  "lru",
  "parity-scale-codec",
@@ -7163,7 +7105,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -7219,7 +7161,7 @@ dependencies = [
  "byteorder",
  "dyn-clonable",
  "ed25519-dalek",
- "futures 0.3.21",
+ "futures",
  "hash-db",
  "hash256-std-hasher",
  "hex",
@@ -7346,7 +7288,7 @@ name = "sp-io"
 version = "6.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "hash-db",
  "libsecp256k1",
  "log",
@@ -7383,7 +7325,7 @@ version = "0.12.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
+ "futures",
  "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.0",
@@ -7478,7 +7420,7 @@ version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "Inflector",
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -7859,7 +7801,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
 dependencies = [
  "frame-system-rpc-runtime-api",
- "futures 0.3.21",
+ "futures",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -8005,18 +7947,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8312,7 +8254,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna 0.2.3",
+ "idna",
  "ipnet",
  "lazy_static",
  "log",
@@ -8320,7 +8262,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tinyvec",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -8347,6 +8289,31 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "try-runtime-cli"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+dependencies = [
+ "clap 3.1.18",
+ "jsonrpsee",
+ "log",
+ "parity-scale-codec",
+ "remote-externalities",
+ "sc-chain-spec",
+ "sc-cli",
+ "sc-executor",
+ "sc-service",
+ "serde",
+ "sp-core",
+ "sp-externalities",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-version",
+ "zstd",
+]
 
 [[package]]
 name = "tt-call"
@@ -8471,25 +8438,14 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.3",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -8663,7 +8619,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "js-sys",
  "parking_lot 0.11.2",
  "pin-utils",
@@ -9080,7 +9036,7 @@ dependencies = [
  "rand 0.7.3",
  "sha-1 0.8.2",
  "slab",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -9119,7 +9075,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0608f53c1dc0bad505d03a34bbd49fbf2ad7b51eb036123e896365532745a1"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,6 +1464,7 @@ dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-primitives",
  "log",
+ "parity-scale-codec",
  "serde",
  "serde_json",
  "sp-core",
@@ -8326,7 +8327,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,21 +10,21 @@ members = [
 ]
 
 #only while debugging
-[patch."https://github.com/encointer/pallets"]
-encointer-balances-tx-payment = { path = "../encointer-pallets/balances-tx-payment" }
-encointer-ceremonies-assignment = { path = "../encointer-pallets/ceremonies/assignment" }
-encointer-primitives = { path = "../encointer-pallets/primitives" }
-pallet-encointer-ceremonies = { path = "../encointer-pallets/ceremonies" }
-pallet-encointer-ceremonies-rpc = { path = "../encointer-pallets/ceremonies/rpc" }
-pallet-encointer-ceremonies-rpc-runtime-api = { path = "../encointer-pallets/ceremonies/rpc/runtime-api" }
-pallet-encointer-communities = { path = "../encointer-pallets/communities" }
-pallet-encointer-communities-rpc = { path = "../encointer-pallets/communities/rpc" }
-pallet-encointer-communities-rpc-runtime-api = { path = "../encointer-pallets/communities/rpc/runtime-api" }
-pallet-encointer-balances = { path = "../encointer-pallets/balances" }
-pallet-encointer-scheduler = { path = "../encointer-pallets/scheduler" }
-pallet-encointer-bazaar = { path = "../encointer-pallets/bazaar" }
-pallet-encointer-bazaar-rpc = { path = "../encointer-pallets/bazaar/rpc" }
-pallet-encointer-bazaar-rpc-runtime-api = { path = "../encointer-pallets/bazaar/rpc/runtime-api" }
+#[patch."https://github.com/encointer/pallets"]
+#encointer-balances-tx-payment = { path = "../encointer-pallets/balances-tx-payment" }
+#encointer-ceremonies-assignment = { path = "../encointer-pallets/ceremonies/assignment" }
+#encointer-primitives = { path = "../encointer-pallets/primitives" }
+#pallet-encointer-ceremonies = { path = "../encointer-pallets/ceremonies" }
+#pallet-encointer-ceremonies-rpc = { path = "../encointer-pallets/ceremonies/rpc" }
+#pallet-encointer-ceremonies-rpc-runtime-api = { path = "../encointer-pallets/ceremonies/rpc/runtime-api" }
+#pallet-encointer-communities = { path = "../encointer-pallets/communities" }
+#pallet-encointer-communities-rpc = { path = "../encointer-pallets/communities/rpc" }
+#pallet-encointer-communities-rpc-runtime-api = { path = "../encointer-pallets/communities/rpc/runtime-api" }
+#pallet-encointer-balances = { path = "../encointer-pallets/balances" }
+#pallet-encointer-scheduler = { path = "../encointer-pallets/scheduler" }
+#pallet-encointer-bazaar = { path = "../encointer-pallets/bazaar" }
+#pallet-encointer-bazaar-rpc = { path = "../encointer-pallets/bazaar/rpc" }
+#pallet-encointer-bazaar-rpc-runtime-api = { path = "../encointer-pallets/bazaar/rpc/runtime-api" }
 
 #[patch."https://github.com/scs/substrate-api-client"]
 #substrate-api-client = { path = "../substrate-api-client" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,21 +10,21 @@ members = [
 ]
 
 #only while debugging
-#[patch."https://github.com/encointer/pallets"]
-#encointer-balances-tx-payment = { path = "../encointer-pallets/balances-tx-payment" }
-#encointer-ceremonies-assignment = { path = "../encointer-pallets/ceremonies/assignment" }
-#encointer-primitives = { path = "../encointer-pallets/primitives" }
-#pallet-encointer-ceremonies = { path = "../encointer-pallets/ceremonies" }
-#pallet-encointer-ceremonies-rpc = { path = "../encointer-pallets/ceremonies/rpc" }
-#pallet-encointer-ceremonies-rpc-runtime-api = { path = "../encointer-pallets/ceremonies/rpc/runtime-api" }
-#pallet-encointer-communities = { path = "../encointer-pallets/communities" }
-#pallet-encointer-communities-rpc = { path = "../encointer-pallets/communities/rpc" }
-#pallet-encointer-communities-rpc-runtime-api = { path = "../encointer-pallets/communities/rpc/runtime-api" }
-#pallet-encointer-balances = { path = "../encointer-pallets/balances" }
-#pallet-encointer-scheduler = { path = "../encointer-pallets/scheduler" }
-#pallet-encointer-bazaar = { path = "../encointer-pallets/bazaar" }
-#pallet-encointer-bazaar-rpc = { path = "../encointer-pallets/bazaar/rpc" }
-#pallet-encointer-bazaar-rpc-runtime-api = { path = "../encointer-pallets/bazaar/rpc/runtime-api" }
+[patch."https://github.com/encointer/pallets"]
+encointer-balances-tx-payment = { path = "../encointer-pallets/balances-tx-payment" }
+encointer-ceremonies-assignment = { path = "../encointer-pallets/ceremonies/assignment" }
+encointer-primitives = { path = "../encointer-pallets/primitives" }
+pallet-encointer-ceremonies = { path = "../encointer-pallets/ceremonies" }
+pallet-encointer-ceremonies-rpc = { path = "../encointer-pallets/ceremonies/rpc" }
+pallet-encointer-ceremonies-rpc-runtime-api = { path = "../encointer-pallets/ceremonies/rpc/runtime-api" }
+pallet-encointer-communities = { path = "../encointer-pallets/communities" }
+pallet-encointer-communities-rpc = { path = "../encointer-pallets/communities/rpc" }
+pallet-encointer-communities-rpc-runtime-api = { path = "../encointer-pallets/communities/rpc/runtime-api" }
+pallet-encointer-balances = { path = "../encointer-pallets/balances" }
+pallet-encointer-scheduler = { path = "../encointer-pallets/scheduler" }
+pallet-encointer-bazaar = { path = "../encointer-pallets/bazaar" }
+pallet-encointer-bazaar-rpc = { path = "../encointer-pallets/bazaar/rpc" }
+pallet-encointer-bazaar-rpc-runtime-api = { path = "../encointer-pallets/bazaar/rpc/runtime-api" }
 
 #[patch."https://github.com/scs/substrate-api-client"]
 #substrate-api-client = { path = "../substrate-api-client" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -28,8 +28,8 @@ pallet-encointer-communities = { git = "https://github.com/encointer/pallets", b
 pallet-encointer-scheduler = { git = "https://github.com/encointer/pallets", branch = "master" }
 
 # scs deps
-substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "master" }
-substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "master" }
+substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "cl/better-generics" }
+substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "cl/better-generics" }
 
 # substrate deps
 frame-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "master" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -28,8 +28,8 @@ pallet-encointer-communities = { git = "https://github.com/encointer/pallets", b
 pallet-encointer-scheduler = { git = "https://github.com/encointer/pallets", branch = "master" }
 
 # scs deps
-substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "cl/encointer-community-currency-fees-hotfix"}
-substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "cl/encointer-community-currency-fees-hotfix"}
+substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "master" }
+substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "master" }
 
 # substrate deps
 frame-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "master" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -28,8 +28,8 @@ pallet-encointer-communities = { git = "https://github.com/encointer/pallets", b
 pallet-encointer-scheduler = { git = "https://github.com/encointer/pallets", branch = "master" }
 
 # scs deps
-substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "cl/better-generics" }
-substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "cl/better-generics" }
+substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "master" }
+substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "master" }
 
 # substrate deps
 frame-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "master" }

--- a/client/encointer-api-client-extension/Cargo.toml
+++ b/client/encointer-api-client-extension/Cargo.toml
@@ -15,6 +15,7 @@ encointer-ceremonies-assignment = { git = "https://github.com/encointer/pallets"
 
 # scs deps
 substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "master"}
+ac-primitives = { git = "https://github.com/scs/substrate-api-client", branch = "master"}
 substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "master"}
 
 # substrate deps

--- a/client/encointer-api-client-extension/Cargo.toml
+++ b/client/encointer-api-client-extension/Cargo.toml
@@ -14,9 +14,9 @@ encointer-primitives = { git = "https://github.com/encointer/pallets", branch = 
 encointer-ceremonies-assignment = { git = "https://github.com/encointer/pallets", branch = "master" }
 
 # scs deps
-substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "master"}
-ac-primitives = { git = "https://github.com/scs/substrate-api-client", branch = "master"}
-substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "master"}
+substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "cl/better-generics"}
+ac-primitives = { git = "https://github.com/scs/substrate-api-client", branch = "cl/better-generics"}
+substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "cl/better-generics"}
 
 # substrate deps
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master" }

--- a/client/encointer-api-client-extension/Cargo.toml
+++ b/client/encointer-api-client-extension/Cargo.toml
@@ -14,8 +14,8 @@ encointer-primitives = { git = "https://github.com/encointer/pallets", branch = 
 encointer-ceremonies-assignment = { git = "https://github.com/encointer/pallets", branch = "master" }
 
 # scs deps
-substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "cl/better-generics"}
-substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "cl/better-generics"}
+substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "master"}
+substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "master"}
 
 # substrate deps
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master" }

--- a/client/encointer-api-client-extension/Cargo.toml
+++ b/client/encointer-api-client-extension/Cargo.toml
@@ -15,7 +15,6 @@ encointer-ceremonies-assignment = { git = "https://github.com/encointer/pallets"
 
 # scs deps
 substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "cl/better-generics"}
-ac-primitives = { git = "https://github.com/scs/substrate-api-client", branch = "cl/better-generics"}
 substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "cl/better-generics"}
 
 # substrate deps

--- a/client/encointer-api-client-extension/Cargo.toml
+++ b/client/encointer-api-client-extension/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.2"
 edition = "2021"
 
 [dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 log = "0.4.14"
 serde_json = { version = "1.0.79"}
 serde = { features = ["derive"], version = "1.0.132" }

--- a/client/encointer-api-client-extension/Cargo.toml
+++ b/client/encointer-api-client-extension/Cargo.toml
@@ -13,8 +13,8 @@ encointer-primitives = { git = "https://github.com/encointer/pallets", branch = 
 encointer-ceremonies-assignment = { git = "https://github.com/encointer/pallets", branch = "master" }
 
 # scs deps
-substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "cl/encointer-community-currency-fees-hotfix"}
-substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "cl/encointer-community-currency-fees-hotfix"}
+substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "master"}
+substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client", branch = "master"}
 
 # substrate deps
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master" }

--- a/client/encointer-api-client-extension/src/extrinsic_params.rs
+++ b/client/encointer-api-client-extension/src/extrinsic_params.rs
@@ -1,4 +1,4 @@
-use ac_primitives::{BaseExtrinsicParams, BaseExtrinsicParamsBuilder, SubstrateDefaultSignedExtra, UncheckedExtrinsicV4};
+use substrate_api_client::{BaseExtrinsicParams, BaseExtrinsicParamsBuilder, SubstrateDefaultSignedExtra, UncheckedExtrinsicV4};
 use codec::{Decode, Encode};
 
 /// A struct representing the signed extra and additional parameters required

--- a/client/encointer-api-client-extension/src/extrinsic_params.rs
+++ b/client/encointer-api-client-extension/src/extrinsic_params.rs
@@ -8,7 +8,7 @@ pub type CommunityCurrencyTipExtrinsicParams = BaseExtrinsicParams<AssetTip>;
 /// This is what you provide to methods like `sign_and_submit()`.
 pub type CommunityCurrencyTipExtrinsicParamsBuilder = BaseExtrinsicParamsBuilder<AssetTip>;
 
-pub type EncointerXt<Call> = UncheckedExtrinsicV4<Call, SubstrateDefaultSignedExtra>;
+pub type EncointerXt<Call> = UncheckedExtrinsicV4<Call, SubstrateDefaultSignedExtra<AssetTip>>;
 
 
 /// A tip payment made in the form of a specific asset.

--- a/client/encointer-api-client-extension/src/extrinsic_params.rs
+++ b/client/encointer-api-client-extension/src/extrinsic_params.rs
@@ -1,4 +1,5 @@
 use codec::{Decode, Encode};
+use encointer_primitives::communities::CommunityIdentifier;
 use substrate_api_client::{
 	BaseExtrinsicParams, BaseExtrinsicParamsBuilder, SubstrateDefaultSignedExtra,
 	UncheckedExtrinsicV4,
@@ -18,7 +19,7 @@ pub type EncointerXt<Call> = UncheckedExtrinsicV4<Call, SubstrateDefaultSignedEx
 pub struct AssetTip {
 	#[codec(compact)]
 	tip: u128,
-	asset: Option<u32>,
+	asset: Option<CommunityIdentifier>,
 }
 
 impl AssetTip {
@@ -29,7 +30,7 @@ impl AssetTip {
 
 	/// Designate the tip as being of a particular asset class.
 	/// If this is not set, then the native currency is used.
-	pub fn of_asset(mut self, asset: u32) -> Self {
+	pub fn of_asset(mut self, asset: CommunityIdentifier) -> Self {
 		self.asset = Some(asset);
 		self
 	}

--- a/client/encointer-api-client-extension/src/extrinsic_params.rs
+++ b/client/encointer-api-client-extension/src/extrinsic_params.rs
@@ -1,5 +1,5 @@
-use ac_primitives::{BaseExtrinsicParams, BaseExtrinsicParamsBuilder};
-use codec::{Compact, Decode, Encode};
+use ac_primitives::{BaseExtrinsicParams, BaseExtrinsicParamsBuilder, SubstrateDefaultSignedExtra, UncheckedExtrinsicV4};
+use codec::{Decode, Encode};
 
 /// A struct representing the signed extra and additional parameters required
 /// to construct a transaction and pay in asset fees
@@ -7,6 +7,8 @@ pub type CommunityCurrencyTipExtrinsicParams = BaseExtrinsicParams<AssetTip>;
 /// A builder which leads to [`CommunityCurrencyTipExtrinsicParams`] being constructed.
 /// This is what you provide to methods like `sign_and_submit()`.
 pub type CommunityCurrencyTipExtrinsicParamsBuilder = BaseExtrinsicParamsBuilder<AssetTip>;
+
+pub type EncointerXt<Call> = UncheckedExtrinsicV4<Call, SubstrateDefaultSignedExtra>;
 
 
 /// A tip payment made in the form of a specific asset.

--- a/client/encointer-api-client-extension/src/extrinsic_params.rs
+++ b/client/encointer-api-client-extension/src/extrinsic_params.rs
@@ -1,5 +1,8 @@
-use substrate_api_client::{BaseExtrinsicParams, BaseExtrinsicParamsBuilder, SubstrateDefaultSignedExtra, UncheckedExtrinsicV4};
 use codec::{Decode, Encode};
+use substrate_api_client::{
+	BaseExtrinsicParams, BaseExtrinsicParamsBuilder, SubstrateDefaultSignedExtra,
+	UncheckedExtrinsicV4,
+};
 
 /// A struct representing the signed extra and additional parameters required
 /// to construct a transaction and pay in asset fees
@@ -9,7 +12,6 @@ pub type CommunityCurrencyTipExtrinsicParams = BaseExtrinsicParams<AssetTip>;
 pub type CommunityCurrencyTipExtrinsicParamsBuilder = BaseExtrinsicParamsBuilder<AssetTip>;
 
 pub type EncointerXt<Call> = UncheckedExtrinsicV4<Call, SubstrateDefaultSignedExtra<AssetTip>>;
-
 
 /// A tip payment made in the form of a specific asset.
 #[derive(Copy, Clone, Debug, Default, Decode, Encode, Eq, PartialEq)]
@@ -22,10 +24,7 @@ pub struct AssetTip {
 impl AssetTip {
 	/// Create a new tip of the amount provided.
 	pub fn new(amount: u128) -> Self {
-		AssetTip {
-			tip: amount,
-			asset: None,
-		}
+		AssetTip { tip: amount, asset: None }
 	}
 
 	/// Designate the tip as being of a particular asset class.

--- a/client/encointer-api-client-extension/src/extrinsic_params.rs
+++ b/client/encointer-api-client-extension/src/extrinsic_params.rs
@@ -7,43 +7,45 @@ use substrate_api_client::{
 
 /// A struct representing the signed extra and additional parameters required
 /// to construct a transaction and pay in asset fees
-pub type CommunityCurrencyTipExtrinsicParams = BaseExtrinsicParams<AssetTip>;
+pub type CommunityCurrencyTipExtrinsicParams = BaseExtrinsicParams<CommunityCurrencyTip>;
 /// A builder which leads to [`CommunityCurrencyTipExtrinsicParams`] being constructed.
 /// This is what you provide to methods like `sign_and_submit()`.
-pub type CommunityCurrencyTipExtrinsicParamsBuilder = BaseExtrinsicParamsBuilder<AssetTip>;
+pub type CommunityCurrencyTipExtrinsicParamsBuilder =
+	BaseExtrinsicParamsBuilder<CommunityCurrencyTip>;
 
-pub type EncointerXt<Call> = UncheckedExtrinsicV4<Call, SubstrateDefaultSignedExtra<AssetTip>>;
+pub type EncointerXt<Call> =
+	UncheckedExtrinsicV4<Call, SubstrateDefaultSignedExtra<CommunityCurrencyTip>>;
 
 /// A tip payment made in the form of a specific asset.
 #[derive(Copy, Clone, Debug, Default, Decode, Encode, Eq, PartialEq)]
-pub struct AssetTip {
+pub struct CommunityCurrencyTip {
 	#[codec(compact)]
 	tip: u128,
 	asset: Option<CommunityIdentifier>,
 }
 
-impl AssetTip {
+impl CommunityCurrencyTip {
 	/// Create a new tip of the amount provided.
 	pub fn new(amount: u128) -> Self {
-		AssetTip { tip: amount, asset: None }
+		CommunityCurrencyTip { tip: amount, asset: None }
 	}
 
 	/// Designate the tip as being of a particular asset class.
 	/// If this is not set, then the native currency is used.
-	pub fn of_asset(mut self, asset: CommunityIdentifier) -> Self {
+	pub fn of_community(mut self, asset: CommunityIdentifier) -> Self {
 		self.asset = Some(asset);
 		self
 	}
 }
 
-impl From<u128> for AssetTip {
+impl From<u128> for CommunityCurrencyTip {
 	fn from(n: u128) -> Self {
-		AssetTip::new(n)
+		CommunityCurrencyTip::new(n)
 	}
 }
 
-impl From<AssetTip> for u128 {
-	fn from(tip: AssetTip) -> Self {
+impl From<CommunityCurrencyTip> for u128 {
+	fn from(tip: CommunityCurrencyTip) -> Self {
 		tip.tip
 	}
 }

--- a/client/encointer-api-client-extension/src/extrinsic_params.rs
+++ b/client/encointer-api-client-extension/src/extrinsic_params.rs
@@ -1,0 +1,47 @@
+use ac_primitives::{BaseExtrinsicParams, BaseExtrinsicParamsBuilder};
+use codec::{Compact, Decode, Encode};
+
+/// A struct representing the signed extra and additional parameters required
+/// to construct a transaction and pay in asset fees
+pub type CommunityCurrencyTipExtrinsicParams = BaseExtrinsicParams<AssetTip>;
+/// A builder which leads to [`CommunityCurrencyTipExtrinsicParams`] being constructed.
+/// This is what you provide to methods like `sign_and_submit()`.
+pub type CommunityCurrencyTipExtrinsicParamsBuilder = BaseExtrinsicParamsBuilder<AssetTip>;
+
+
+/// A tip payment made in the form of a specific asset.
+#[derive(Copy, Clone, Debug, Default, Decode, Encode, Eq, PartialEq)]
+pub struct AssetTip {
+	#[codec(compact)]
+	tip: u128,
+	asset: Option<u32>,
+}
+
+impl AssetTip {
+	/// Create a new tip of the amount provided.
+	pub fn new(amount: u128) -> Self {
+		AssetTip {
+			tip: amount,
+			asset: None,
+		}
+	}
+
+	/// Designate the tip as being of a particular asset class.
+	/// If this is not set, then the native currency is used.
+	pub fn of_asset(mut self, asset: u32) -> Self {
+		self.asset = Some(asset);
+		self
+	}
+}
+
+impl From<u128> for AssetTip {
+	fn from(n: u128) -> Self {
+		AssetTip::new(n)
+	}
+}
+
+impl From<AssetTip> for u128 {
+	fn from(tip: AssetTip) -> Self {
+		tip.tip
+	}
+}

--- a/client/encointer-api-client-extension/src/lib.rs
+++ b/client/encointer-api-client-extension/src/lib.rs
@@ -8,6 +8,7 @@ pub type Api = substrate_api_client::Api<sr25519::Pair, WsRpcClient, extrinsic_p
 pub use ceremonies::*;
 pub use communities::*;
 pub use scheduler::*;
+pub use extrinsic_params::*;
 
 mod ceremonies;
 mod communities;

--- a/client/encointer-api-client-extension/src/lib.rs
+++ b/client/encointer-api-client-extension/src/lib.rs
@@ -3,14 +3,18 @@ use substrate_api_client::rpc::WsRpcClient;
 
 pub use substrate_api_client::{ApiClientError, ApiResult as Result};
 
-pub type Api = substrate_api_client::Api<sr25519::Pair, WsRpcClient, extrinsic_params::CommunityCurrencyTipExtrinsicParams>;
+pub type Api = substrate_api_client::Api<
+	sr25519::Pair,
+	WsRpcClient,
+	extrinsic_params::CommunityCurrencyTipExtrinsicParams,
+>;
 
 pub use ceremonies::*;
 pub use communities::*;
-pub use scheduler::*;
 pub use extrinsic_params::*;
+pub use scheduler::*;
 
 mod ceremonies;
 mod communities;
-mod scheduler;
 mod extrinsic_params;
+mod scheduler;

--- a/client/encointer-api-client-extension/src/lib.rs
+++ b/client/encointer-api-client-extension/src/lib.rs
@@ -3,7 +3,7 @@ use substrate_api_client::rpc::WsRpcClient;
 
 pub use substrate_api_client::{ApiClientError, ApiResult as Result};
 
-pub type Api = substrate_api_client::Api<sr25519::Pair, WsRpcClient>;
+pub type Api = substrate_api_client::Api<sr25519::Pair, WsRpcClient, extrinsic_params::CommunityCurrencyTipExtrinsicParams>;
 
 pub use ceremonies::*;
 pub use communities::*;
@@ -12,3 +12,4 @@ pub use scheduler::*;
 mod ceremonies;
 mod communities;
 mod scheduler;
+mod extrinsic_params;

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -39,7 +39,7 @@ use clap_nested::{Command, Commander};
 use cli_args::{EncointerArgs, EncointerArgsExtractor};
 use codec::{Compact, Decode, Encode};
 use encointer_api_client_extension::{
-	CeremoniesApi, CommunitiesApi, SchedulerApi, ENCOINTER_CEREMONIES,
+	Api, CeremoniesApi, CommunitiesApi, EncointerXt, SchedulerApi, ENCOINTER_CEREMONIES,
 };
 use encointer_node_notee_runtime::{
 	AccountId, BalanceEntry, BalanceType, BlockNumber, Event, Hash, Header, Moment, Signature,
@@ -67,10 +67,9 @@ use std::{
 };
 use substrate_api_client::{
 	compose_call, compose_extrinsic, compose_extrinsic_offline, rpc::WsRpcClient,
-	utils::FromHexString, ApiClientError, ApiResult, GenericAddress, Metadata,
-	XtStatus, ExtrinsicParams
+	utils::FromHexString, ApiClientError, ApiResult, ExtrinsicParams, GenericAddress, Metadata,
+	XtStatus,
 };
-use encointer_api_client_extension::{EncointerXt, Api};
 use substrate_client_keystore::{KeystoreExt, LocalKeystore};
 
 type AccountPublic = <Signature as Verify>::Signer;
@@ -1270,10 +1269,7 @@ fn get_block_number(api: &Api) -> BlockNumber {
 	hdr.number
 }
 
-fn get_demurrage_per_block(
-	api: &Api,
-	cid: CommunityIdentifier,
-) -> Demurrage {
+fn get_demurrage_per_block(api: &Api, cid: CommunityIdentifier) -> Demurrage {
 	let d: Option<Demurrage> = api
 		.get_storage_map("EncointerBalances", "DemurragePerBlock", cid, None)
 		.unwrap();
@@ -1297,10 +1293,7 @@ fn get_ceremony_index(api: &Api) -> CeremonyIndexType {
 		.unwrap()
 }
 
-fn get_attestee_count(
-	api: &Api,
-	key: CommunityCeremony,
-) -> ParticipantIndexType {
+fn get_attestee_count(api: &Api, key: CommunityCeremony) -> ParticipantIndexType {
 	api.get_storage_map("EncointerCeremonies", "AttestationCount", key, None)
 		.unwrap()
 		.or(Some(0))
@@ -1364,9 +1357,7 @@ fn new_claim_for(
 	claim.encode()
 }
 
-fn get_community_identifiers(
-	api: &Api,
-) -> Option<Vec<CommunityIdentifier>> {
+fn get_community_identifiers(api: &Api) -> Option<Vec<CommunityIdentifier>> {
 	api.get_storage_value("EncointerCommunities", "CommunityIdentifiers", None)
 		.unwrap()
 }
@@ -1386,10 +1377,7 @@ fn get_cid_names(api: &Api) -> Option<Vec<CidName>> {
 	Some(serde_json::from_str(&n).unwrap())
 }
 
-fn get_businesses(
-	api: &Api,
-	cid: CommunityIdentifier,
-) -> Option<Vec<BusinessData>> {
+fn get_businesses(api: &Api, cid: CommunityIdentifier) -> Option<Vec<BusinessData>> {
 	let req = json!({
 		"method": "encointer_bazaarGetBusinesses",
 		"params": vec![cid],
@@ -1401,10 +1389,7 @@ fn get_businesses(
 	Some(serde_json::from_str(&n).unwrap())
 }
 
-fn get_offerings(
-	api: &Api,
-	cid: CommunityIdentifier,
-) -> Option<Vec<OfferingData>> {
+fn get_offerings(api: &Api, cid: CommunityIdentifier) -> Option<Vec<OfferingData>> {
 	let req = json!({
 		"method": "encointer_bazaarGetOfferings",
 		"params": vec![cid],

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -67,9 +67,10 @@ use std::{
 };
 use substrate_api_client::{
 	compose_call, compose_extrinsic, compose_extrinsic_offline, rpc::WsRpcClient,
-	utils::FromHexString, Api, ApiClientError, ApiResult, GenericAddress, Metadata,
-	UncheckedExtrinsicV4, XtStatus,
+	utils::FromHexString, ApiClientError, ApiResult, GenericAddress, Metadata,
+	XtStatus, ExtrinsicParams
 };
+use encointer_api_client_extension::{EncointerXt, Api};
 use substrate_client_keystore::{KeystoreExt, LocalKeystore};
 
 type AccountPublic = <Signature as Verify>::Signer;
@@ -188,15 +189,10 @@ fn main() {
                             GenericAddress::Id(to.clone()),
                             Compact(amount)
                         );
-                        let xt: UncheckedExtrinsicV4<_> = compose_extrinsic_offline!(
+                        let xt: EncointerXt<_> = compose_extrinsic_offline!(
                             api.clone().signer.unwrap(),
                             call.clone(),
-                            nonce,
-                            Era::Immortal,
-                            api.genesis_hash,
-                            api.genesis_hash,
-                            api.runtime_version.spec_version,
-                            api.runtime_version.transaction_version
+                            api.extrinsic_params(nonce)
                         );
                         ensure_payment(&api, &xt.hex_encode());
                         // send and watch extrinsic until finalized
@@ -293,7 +289,7 @@ fn main() {
                             let cid = verify_cid(&_api, cid_str);
                             let amount = BalanceType::from_str(matches.value_of("amount").unwrap())
                                 .expect("amount can be converted to fixpoint");
-                            let xt: UncheckedExtrinsicV4<_> = compose_extrinsic!(
+                            let xt: EncointerXt<_> = compose_extrinsic!(
                                 _api.clone(),
                                 "EncointerBalances",
                                 "transfer",
@@ -711,7 +707,7 @@ fn main() {
                         std::process::exit(exit_code::WRONG_PHASE);
                     }
                     let _api = api.clone().set_signer(sr25519_core::Pair::from(signer.clone()));
-                    let xt: UncheckedExtrinsicV4<_> = compose_extrinsic!(
+                    let xt: EncointerXt<_> = compose_extrinsic!(
                         _api.clone(),
                         "EncointerCeremonies",
                         "register_participant",
@@ -816,7 +812,7 @@ fn main() {
                     info!("send attest_claims by {}", who.public());
 
                     let api = get_chain_api(matches).set_signer(who.clone().into());
-                    let xt: UncheckedExtrinsicV4<_> = compose_extrinsic!(
+                    let xt: EncointerXt<_> = compose_extrinsic!(
                         api.clone(),
                         "EncointerCeremonies",
                         "attest_claims",
@@ -880,7 +876,7 @@ fn main() {
                             let signer = matches.signer_arg().map(get_pair_from_str).unwrap();
                             let api = api.set_signer(signer.clone().into());
 
-                            let xt: UncheckedExtrinsicV4<_> = compose_extrinsic!(
+                            let xt: EncointerXt<_> = compose_extrinsic!(
                                 api.clone(),
                                 ENCOINTER_CEREMONIES,
                                 "claim_rewards",
@@ -1051,7 +1047,7 @@ fn main() {
                         batch_call.clone()
                     );
                     info!("raw sudo batch call to sign with js/apps {}: 0x{}", cid, hex::encode(unsigned_sudo_call.encode()));
-                    let xt: UncheckedExtrinsicV4<_> = compose_extrinsic!(
+                    let xt: EncointerXt<_> = compose_extrinsic!(
                         api,
                         "Sudo",
                         "sudo",
@@ -1108,7 +1104,7 @@ fn main() {
         .run();
 }
 
-fn get_chain_api(matches: &ArgMatches<'_>) -> Api<sr25519::Pair, WsRpcClient> {
+fn get_chain_api(matches: &ArgMatches<'_>) -> Api {
 	let url = format!(
 		"{}:{}",
 		matches.value_of("node-url").unwrap(),
@@ -1116,10 +1112,10 @@ fn get_chain_api(matches: &ArgMatches<'_>) -> Api<sr25519::Pair, WsRpcClient> {
 	);
 	debug!("connecting to {}", url);
 	let client = WsRpcClient::new(&url);
-	Api::<sr25519::Pair, _>::new(client).unwrap()
+	Api::new(client).unwrap()
 }
 
-fn reasonable_native_balance(api: &Api<sr25519::Pair, WsRpcClient>) -> u128 {
+fn reasonable_native_balance(api: &Api) -> u128 {
 	let xt = api.balance_transfer(GenericAddress::Id(AccountKeyring::Alice.into()), 9999);
 	let fee = api
 		.get_fee_details(&xt.hex_encode(), None)
@@ -1251,14 +1247,14 @@ fn listen(matches: &ArgMatches<'_>) {
 /// Extracts api and cid from `matches` and execute the given `closure` with them.
 fn extract_and_execute<T>(
 	matches: &ArgMatches<'_>,
-	closure: impl FnOnce(Api<sr25519::Pair, WsRpcClient>, CommunityIdentifier) -> T,
+	closure: impl FnOnce(Api, CommunityIdentifier) -> T,
 ) -> T {
 	let api = get_chain_api(matches);
 	let cid = verify_cid(&api, matches.cid_arg().expect("please supply argument --cid"));
 	closure(api, cid)
 }
 
-fn verify_cid(api: &Api<sr25519::Pair, WsRpcClient>, cid: &str) -> CommunityIdentifier {
+fn verify_cid(api: &Api, cid: &str) -> CommunityIdentifier {
 	let cids = get_community_identifiers(&api).expect("no community registered");
 	let cid = CommunityIdentifier::from_str(cid).unwrap();
 	if !cids.contains(&cid) {
@@ -1267,7 +1263,7 @@ fn verify_cid(api: &Api<sr25519::Pair, WsRpcClient>, cid: &str) -> CommunityIden
 	cid
 }
 
-fn get_block_number(api: &Api<sr25519::Pair, WsRpcClient>) -> BlockNumber {
+fn get_block_number(api: &Api) -> BlockNumber {
 	let hdr: Header = api.get_header(None).unwrap().unwrap();
 	debug!("decoded: {:?}", hdr);
 	//let hdr: Header= Decode::decode(&mut .as_bytes()).unwrap();
@@ -1275,7 +1271,7 @@ fn get_block_number(api: &Api<sr25519::Pair, WsRpcClient>) -> BlockNumber {
 }
 
 fn get_demurrage_per_block(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	cid: CommunityIdentifier,
 ) -> Demurrage {
 	let d: Option<Demurrage> = api
@@ -1295,14 +1291,14 @@ fn get_demurrage_per_block(
 	}
 }
 
-fn get_ceremony_index(api: &Api<sr25519::Pair, WsRpcClient>) -> CeremonyIndexType {
+fn get_ceremony_index(api: &Api) -> CeremonyIndexType {
 	api.get_storage_value("EncointerScheduler", "CurrentCeremonyIndex", None)
 		.unwrap()
 		.unwrap()
 }
 
 fn get_attestee_count(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	key: CommunityCeremony,
 ) -> ParticipantIndexType {
 	api.get_storage_map("EncointerCeremonies", "AttestationCount", key, None)
@@ -1312,7 +1308,7 @@ fn get_attestee_count(
 }
 
 fn get_attestees(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	key: CommunityCeremony,
 	windex: ParticipantIndexType,
 ) -> Option<Vec<AccountId>> {
@@ -1321,7 +1317,7 @@ fn get_attestees(
 }
 
 fn get_participant_attestation_index(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	key: CommunityCeremony,
 	accountid: &AccountId,
 ) -> Option<ParticipantIndexType> {
@@ -1330,7 +1326,7 @@ fn get_participant_attestation_index(
 }
 
 fn new_claim_for(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	claimant: &sr25519::Pair,
 	cid: CommunityIdentifier,
 	n_participants: u32,
@@ -1369,14 +1365,14 @@ fn new_claim_for(
 }
 
 fn get_community_identifiers(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 ) -> Option<Vec<CommunityIdentifier>> {
 	api.get_storage_value("EncointerCommunities", "CommunityIdentifiers", None)
 		.unwrap()
 }
 
 /// This rpc needs to have offchain indexing enabled in the node.
-fn get_cid_names(api: &Api<sr25519::Pair, WsRpcClient>) -> Option<Vec<CidName>> {
+fn get_cid_names(api: &Api) -> Option<Vec<CidName>> {
 	let req = json!({
 		"method": "encointer_getAllCommunities",
 		"params": [],
@@ -1391,7 +1387,7 @@ fn get_cid_names(api: &Api<sr25519::Pair, WsRpcClient>) -> Option<Vec<CidName>> 
 }
 
 fn get_businesses(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	cid: CommunityIdentifier,
 ) -> Option<Vec<BusinessData>> {
 	let req = json!({
@@ -1406,7 +1402,7 @@ fn get_businesses(
 }
 
 fn get_offerings(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	cid: CommunityIdentifier,
 ) -> Option<Vec<OfferingData>> {
 	let req = json!({
@@ -1424,7 +1420,7 @@ fn get_offerings(
 }
 
 fn get_offerings_for_business(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	cid: CommunityIdentifier,
 	account_id: AccountId,
 ) -> Option<Vec<OfferingData>> {
@@ -1445,7 +1441,7 @@ fn get_offerings_for_business(
 }
 
 fn get_reputation_history(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	account_id: &AccountId,
 ) -> Option<Vec<(CeremonyIndexType, CommunityReputation)>> {
 	let req = json!({
@@ -1463,7 +1459,7 @@ fn get_reputation_history(
 }
 
 fn get_all_balances(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	account_id: &AccountId,
 ) -> Option<Vec<(CommunityIdentifier, BalanceEntry<BlockNumber>)>> {
 	let req = json!({
@@ -1501,7 +1497,7 @@ fn prove_attendance(
 }
 
 fn get_reputation(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	prover: &AccountId,
 	cid: CommunityIdentifier,
 	cindex: CeremonyIndexType,
@@ -1542,7 +1538,7 @@ fn send_bazaar_xt(matches: &ArgMatches<'_>, business_call: &BazaarCalls) -> Resu
 	let cid = verify_cid(&api, matches.cid_arg().expect("please supply argument --cid"));
 	let ipfs_cid = matches.ipfs_cid_arg().expect("ipfs cid needed");
 
-	let xt: UncheckedExtrinsicV4<_> = compose_extrinsic!(
+	let xt: EncointerXt<_> = compose_extrinsic!(
 		api.clone(),
 		"EncointerBazaar",
 		&business_call.to_string(),
@@ -1557,7 +1553,7 @@ fn send_bazaar_xt(matches: &ArgMatches<'_>, business_call: &BazaarCalls) -> Resu
 }
 
 fn endorse_newcomers(
-	api: &mut Api<sr25519::Pair, WsRpcClient>,
+	api: &mut Api,
 	cid: CommunityIdentifier,
 	matches: &ArgMatches<'_>,
 ) -> Result<(), ApiClientError> {
@@ -1594,7 +1590,7 @@ struct BootstrapperWithTickets {
 }
 
 fn get_bootstrappers_with_remaining_newbie_tickets(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	cid: CommunityIdentifier,
 ) -> Result<Vec<BootstrapperWithTickets>, ApiClientError> {
 	let total_newbie_tickets: u8 = api

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -3,28 +3,23 @@ use codec::{Compact, Encode};
 use encointer_node_notee_runtime::AccountId;
 use encointer_primitives::scheduler::CeremonyIndexType;
 use log::{debug, error, info};
-use sp_application_crypto::sr25519;
 use sp_core::{Pair, H256};
+use encointer_api_client_extension::{Api, EncointerXt};
 use substrate_api_client::{
-	compose_call, compose_extrinsic_offline, rpc::WsRpcClient, Api, ApiClientError,
-	ApiResult as Result, Metadata, UncheckedExtrinsicV4, XtStatus,
+	compose_call, compose_extrinsic_offline, ApiClientError,
+	ApiResult as Result, Metadata, XtStatus, ExtrinsicParams,
 };
 
 /// Wrapper around the `compose_extrinsic_offline!` macro to be less verbose.
 pub fn offline_xt<C: Encode + Clone>(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	call: C,
 	nonce: u32,
-) -> UncheckedExtrinsicV4<C> {
+) -> EncointerXt<C> {
 	compose_extrinsic_offline!(
 		api.clone().signer.unwrap(),
 		call,
-		nonce,
-		Era::Immortal,
-		api.genesis_hash,
-		api.genesis_hash,
-		api.runtime_version.spec_version,
-		api.runtime_version.transaction_version
+		api.extrinsic_params(nonce)
 	)
 }
 
@@ -32,9 +27,9 @@ pub fn offline_xt<C: Encode + Clone>(
 ///
 /// Panics if no signer is set.
 pub fn xt<C: Encode + Clone>(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	call: C,
-) -> UncheckedExtrinsicV4<C> {
+) -> EncointerXt<C> {
 	let nonce = api.get_nonce().unwrap();
 	offline_xt(api, call, nonce)
 }
@@ -71,20 +66,20 @@ pub fn collective_propose_call<Proposal: Encode>(
 		Compact(length_bound)
 	)
 }
-pub fn get_councillors(api: &Api<sr25519::Pair, WsRpcClient>) -> Result<Vec<AccountId>> {
+pub fn get_councillors(api: &Api) -> Result<Vec<AccountId>> {
 	api.get_storage_value("Membership", "Members", None)?
 		.ok_or_else(|| ApiClientError::Other("Couldn't get councillors".into()))
 }
 
 pub fn send_and_wait_for_in_block<C: Encode>(
-	api: &Api<sr25519::Pair, WsRpcClient>,
-	xt: UncheckedExtrinsicV4<C>,
+	api: &Api,
+	xt: EncointerXt<C>,
 ) -> Option<H256> {
 	send_xt_hex_and_wait_for_in_block(api, xt.hex_encode())
 }
 
 pub fn send_xt_hex_and_wait_for_in_block(
-	api: &Api<sr25519::Pair, WsRpcClient>,
+	api: &Api,
 	xt_hex: String,
 ) -> Option<H256> {
 	ensure_payment(&api, &xt_hex);
@@ -114,7 +109,7 @@ pub fn contains_sudo_pallet(metadata: &Metadata) -> bool {
 }
 
 /// Checks if the account has sufficient funds. Exits the process if not.
-pub fn ensure_payment(api: &Api<sr25519::Pair, WsRpcClient>, xt: &str) {
+pub fn ensure_payment(api: &Api, xt: &str) {
 	let signer_balance = match api.get_account_data(&api.signer_account().unwrap()).unwrap() {
 		Some(bal) => bal.free,
 		None => {

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -20,8 +20,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 substrate-build-script-utils = "3.0.0"
 
 [dependencies]
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1.18", features = ["derive"] }
 log = "0.4.14"
+serde_json = "1.0.81"
 
 sc-cli = { version = "0.10.0-dev", features = ["wasmtime"], git = "https://github.com/paritytech/substrate.git",branch = "master" }
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git",branch = "master" }
@@ -40,9 +41,14 @@ sp-finality-grandpa = { version = "4.0.0-dev", git = "https://github.com/parityt
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git",branch = "master" }
 sp-runtime = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git",branch = "master" }
 sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git",branch = "master" }
+sp-inherents = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git",branch = "master" }
+sp-keyring = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git",branch = "master" }
+frame-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git",branch = "master" }
+# encointer-specific
+pallet-asset-tx-payment = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git",branch = "master" }
 
 # These dependencies are used for the node's RPCs
-jsonrpc-core = "18.0.0"
+jsonrpsee = { version = "0.13.1", features = ["server"] }
 sc-rpc = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git",branch = "master" }
 sp-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git",branch = "master" }
 sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git",branch = "master" }
@@ -66,8 +72,15 @@ pallet-encointer-communities-rpc-runtime-api = { git = "https://github.com/encoi
 pallet-encointer-bazaar-rpc = {git = "https://github.com/encointer/pallets", branch = "master"}
 pallet-encointer-bazaar-rpc-runtime-api = {git = "https://github.com/encointer/pallets", branch = "master"}
 
+# CLI-specific dependencies
+try-runtime-cli = { version = "0.10.0-dev", optional = true, git = "https://github.com/paritytech/substrate.git",branch = "master" }
+
+
 [features]
 default = []
 runtime-benchmarks = [
     "encointer-node-notee-runtime/runtime-benchmarks"
 ]
+# Enable features that allow the runtime to be tried and debugged. Name might be subject to change
+# in the near future. Todo: implement try runtime for encointer-pallets
+try-runtime = ["try-runtime-cli"]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -3,7 +3,6 @@ use encointer_node_notee_runtime::{
 	EncointerCeremoniesConfig, EncointerCommunitiesConfig, EncointerSchedulerConfig, GenesisConfig,
 	GrandpaConfig, Signature, SudoConfig, SystemConfig, WASM_BINARY,
 };
-use jsonrpc_core::serde_from_str;
 use sc_service::{ChainType, Properties};
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{sr25519, Pair, Public};
@@ -39,7 +38,7 @@ pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
 }
 
 fn properties() -> Option<Properties> {
-	serde_from_str(
+	serde_json::from_str(
 		r#"{
     "ss58Format": 42,
     "tokenDecimals": 12,

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -36,7 +36,18 @@ pub enum Subcommand {
 	/// Revert the chain to a previous state.
 	Revert(sc_cli::RevertCmd),
 
-	/// The custom benchmark subcommand benchmarking runtime pallets.
-	#[clap(name = "benchmark", about = "Benchmark runtime pallets.")]
+	/// Sub-commands concerned with benchmarking.
+	#[clap(subcommand)]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
+
+	/// Try some command against runtime state.
+	#[cfg(feature = "try-runtime")]
+	TryRuntime(try_runtime_cli::TryRuntimeCmd),
+
+	/// Try some command against runtime state. Note: `try-runtime` feature must be enabled.
+	#[cfg(not(feature = "try-runtime"))]
+	TryRuntime,
+
+	/// Db meta columns information.
+	ChainInfo(sc_cli::ChainInfoCmd),
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -21,8 +21,8 @@ use crate::{
 	command_helper::{inherent_benchmark_data, BenchmarkExtrinsicBuilder},
 	service,
 };
-use frame_benchmarking_cli::{BenchmarkCmd, SUBSTRATE_REFERENCE_HARDWARE};
 use encointer_node_notee_runtime::Block;
+use frame_benchmarking_cli::{BenchmarkCmd, SUBSTRATE_REFERENCE_HARDWARE};
 use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
 use std::sync::Arc;

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -18,11 +18,14 @@
 use crate::{
 	chain_spec,
 	cli::{Cli, Subcommand},
+	command_helper::{inherent_benchmark_data, BenchmarkExtrinsicBuilder},
 	service,
 };
+use frame_benchmarking_cli::{BenchmarkCmd, SUBSTRATE_REFERENCE_HARDWARE};
 use encointer_node_notee_runtime::Block;
 use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
+use std::sync::Arc;
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
@@ -112,19 +115,75 @@ pub fn run() -> sc_cli::Result<()> {
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, backend, .. } =
 					service::new_partial(&config)?;
-				Ok((cmd.run(client, backend), task_manager))
+				let aux_revert = Box::new(|client, _, blocks| {
+					sc_finality_grandpa::revert(client, blocks)?;
+					Ok(())
+				});
+				Ok((cmd.run(client, backend, Some(aux_revert)), task_manager))
 			})
 		},
-		Some(Subcommand::Benchmark(cmd)) =>
-			if cfg!(feature = "runtime-benchmarks") {
-				let runner = cli.create_runner(cmd)?;
+		Some(Subcommand::Benchmark(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
 
-				runner.sync_run(|config| cmd.run::<Block, service::ExecutorDispatch>(config))
-			} else {
-				Err("Benchmarking wasn't enabled when building the node. You can enable it with \
-				     `--features runtime-benchmarks`."
-					.into())
-			},
+			runner.sync_run(|config| {
+				// This switch needs to be in the client, since the client decides
+				// which sub-commands it wants to support.
+				match cmd {
+					BenchmarkCmd::Pallet(cmd) => {
+						if !cfg!(feature = "runtime-benchmarks") {
+							return Err(
+								"Runtime benchmarking wasn't enabled when building the node. \
+							You can enable it with `--features runtime-benchmarks`."
+									.into(),
+							)
+						}
+
+						cmd.run::<Block, service::ExecutorDispatch>(config)
+					},
+					BenchmarkCmd::Block(cmd) => {
+						let PartialComponents { client, .. } = service::new_partial(&config)?;
+						cmd.run(client)
+					},
+					BenchmarkCmd::Storage(cmd) => {
+						let PartialComponents { client, backend, .. } =
+							service::new_partial(&config)?;
+						let db = backend.expose_db();
+						let storage = backend.expose_storage();
+
+						cmd.run(config, client, db, storage)
+					},
+					BenchmarkCmd::Overhead(cmd) => {
+						let PartialComponents { client, .. } = service::new_partial(&config)?;
+						let ext_builder = BenchmarkExtrinsicBuilder::new(client.clone());
+
+						cmd.run(config, client, inherent_benchmark_data()?, Arc::new(ext_builder))
+					},
+					BenchmarkCmd::Machine(cmd) =>
+						cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()),
+				}
+			})
+		},
+		#[cfg(feature = "try-runtime")]
+		Some(Subcommand::TryRuntime(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|config| {
+				// we don't need any of the components of new_partial, just a runtime, or a task
+				// manager to do `async_run`.
+				let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
+				let task_manager =
+					sc_service::TaskManager::new(config.tokio_handle.clone(), registry)
+						.map_err(|e| sc_cli::Error::Service(sc_service::Error::Prometheus(e)))?;
+				Ok((cmd.run::<Block, service::ExecutorDispatch>(config), task_manager))
+			})
+		},
+		#[cfg(not(feature = "try-runtime"))]
+		Some(Subcommand::TryRuntime) => Err("TryRuntime wasn't enabled when building the node. \
+				You can enable it with `--features try-runtime`."
+			.into()),
+		Some(Subcommand::ChainInfo(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.sync_run(|config| cmd.run::<Block>(&config))
+		},
 		None => {
 			let runner = cli.create_runner(&cli.run)?;
 			runner.run_node_until_exit(|config| async move {

--- a/node/src/command_helper.rs
+++ b/node/src/command_helper.rs
@@ -1,0 +1,129 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Contains code to setup the command invocations in [`super::command`] which would
+//! otherwise bloat that module.
+
+use crate::service::FullClient;
+
+use encointer_node_notee_runtime as runtime;
+use runtime::SystemCall;
+use sc_cli::Result;
+use sc_client_api::BlockBackend;
+use sp_core::{Encode, Pair};
+use sp_inherents::{InherentData, InherentDataProvider};
+use sp_keyring::Sr25519Keyring;
+use sp_runtime::{OpaqueExtrinsic, SaturatedConversion};
+
+use std::{sync::Arc, time::Duration};
+
+/// Generates extrinsics for the `benchmark overhead` command.
+///
+/// Note: Should only be used for benchmarking.
+pub struct BenchmarkExtrinsicBuilder {
+	client: Arc<FullClient>,
+}
+
+impl BenchmarkExtrinsicBuilder {
+	/// Creates a new [`Self`] from the given client.
+	pub fn new(client: Arc<FullClient>) -> Self {
+		Self { client }
+	}
+}
+
+impl frame_benchmarking_cli::ExtrinsicBuilder for BenchmarkExtrinsicBuilder {
+	fn remark(&self, nonce: u32) -> std::result::Result<OpaqueExtrinsic, &'static str> {
+		let acc = Sr25519Keyring::Bob.pair();
+		let extrinsic: OpaqueExtrinsic = create_benchmark_extrinsic(
+			self.client.as_ref(),
+			acc,
+			SystemCall::remark { remark: vec![] }.into(),
+			nonce,
+		)
+		.into();
+
+		Ok(extrinsic)
+	}
+}
+
+/// Create a transaction using the given `call`.
+///
+/// Note: Should only be used for benchmarking.
+pub fn create_benchmark_extrinsic(
+	client: &FullClient,
+	sender: sp_core::sr25519::Pair,
+	call: runtime::Call,
+	nonce: u32,
+) -> runtime::UncheckedExtrinsic {
+	let genesis_hash = client.block_hash(0).ok().flatten().expect("Genesis block exists; qed");
+	let best_hash = client.chain_info().best_hash;
+	let best_block = client.chain_info().best_number;
+
+	let period = runtime::BlockHashCount::get()
+		.checked_next_power_of_two()
+		.map(|c| c / 2)
+		.unwrap_or(2) as u64;
+	let extra: runtime::SignedExtra = (
+		frame_system::CheckSpecVersion::<runtime::Runtime>::new(),
+		frame_system::CheckTxVersion::<runtime::Runtime>::new(),
+		frame_system::CheckGenesis::<runtime::Runtime>::new(),
+		frame_system::CheckEra::<runtime::Runtime>::from(sp_runtime::generic::Era::mortal(
+			period,
+			best_block.saturated_into(),
+		)),
+		frame_system::CheckNonce::<runtime::Runtime>::from(nonce),
+		frame_system::CheckWeight::<runtime::Runtime>::new(),
+		pallet_asset_tx_payment::ChargeAssetTxPayment::<runtime::Runtime>::from(0, None),
+	);
+
+	let raw_payload = runtime::SignedPayload::from_raw(
+		call.clone(),
+		extra.clone(),
+		(   // Encointer-change: non zero sender is missing
+			runtime::VERSION.spec_version,
+			runtime::VERSION.transaction_version,
+			genesis_hash,
+			best_hash,
+			(),
+			(),
+			(),
+		),
+	);
+	let signature = raw_payload.using_encoded(|e| sender.sign(e));
+
+	runtime::UncheckedExtrinsic::new_signed(
+		call.clone(),
+		sp_runtime::AccountId32::from(sender.public()).into(),
+		runtime::Signature::Sr25519(signature.clone()),
+		extra.clone(),
+	)
+}
+
+/// Generates inherent data for the `benchmark overhead` command.
+///
+/// Note: Should only be used for benchmarking.
+pub fn inherent_benchmark_data() -> Result<InherentData> {
+	let mut inherent_data = InherentData::new();
+	let d = Duration::from_millis(0);
+	let timestamp = sp_timestamp::InherentDataProvider::new(d.into());
+
+	timestamp
+		.provide_inherent_data(&mut inherent_data)
+		.map_err(|e| format!("creating inherent data: {:?}", e))?;
+	Ok(inherent_data)
+}

--- a/node/src/command_helper.rs
+++ b/node/src/command_helper.rs
@@ -94,7 +94,8 @@ pub fn create_benchmark_extrinsic(
 	let raw_payload = runtime::SignedPayload::from_raw(
 		call.clone(),
 		extra.clone(),
-		(   // Encointer-change: non zero sender is missing
+		(
+			// Encointer-change: non zero sender is missing
 			runtime::VERSION.spec_version,
 			runtime::VERSION.transaction_version,
 			genesis_hash,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -6,6 +6,7 @@ mod chain_spec;
 mod service;
 mod cli;
 mod command;
+mod command_helper;
 mod rpc;
 
 fn main() -> sc_cli::Result<()> {

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -7,8 +7,8 @@
 
 use std::sync::Arc;
 
+use encointer_node_notee_runtime::{opaque::Block, AccountId, Balance, BlockNumber, Index, Moment};
 use jsonrpsee::RpcModule;
-use encointer_node_notee_runtime::{opaque::Block, AccountId, Balance, Index, Moment, BlockNumber};
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
@@ -51,9 +51,9 @@ where
 	TBackend: sc_client_api::Backend<Block>,
 	<TBackend as sc_client_api::Backend<Block>>::OffchainStorage: 'static,
 {
-	use pallet_encointer_communities_rpc::{CommunitiesRpc, CommunitiesApiServer};
-	use pallet_encointer_bazaar_rpc::{BazaarRpc, BazaarApiServer};
-	use pallet_encointer_ceremonies_rpc::{CeremoniesRpc, CeremoniesApiServer};
+	use pallet_encointer_bazaar_rpc::{BazaarApiServer, BazaarRpc};
+	use pallet_encointer_ceremonies_rpc::{CeremoniesApiServer, CeremoniesRpc};
+	use pallet_encointer_communities_rpc::{CommunitiesApiServer, CommunitiesRpc};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
 	use substrate_frame_rpc_system::{System, SystemApiServer};
 
@@ -72,19 +72,20 @@ where
 
 	match backend.offchain_storage() {
 		Some(storage) => {
-			module.merge(CommunitiesRpc::new(
-				client.clone(),
-				storage.clone(),
-				offchain_indexing_enabled,
-				deny_unsafe,
-			).into_rpc())?;
+			module.merge(
+				CommunitiesRpc::new(
+					client.clone(),
+					storage.clone(),
+					offchain_indexing_enabled,
+					deny_unsafe,
+				)
+				.into_rpc(),
+			)?;
 
-			module.merge(CeremoniesRpc::new(
-				client.clone(),
-				deny_unsafe,
-				storage,
-				offchain_indexing_enabled,
-			).into_rpc())?;
+			module.merge(
+				CeremoniesRpc::new(client.clone(), deny_unsafe, storage, offchain_indexing_enabled)
+					.into_rpc(),
+			)?;
 		},
 		None => log::warn!(
 			"Offchain caching disabled, due to lack of offchain storage support in backend. \n 

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -7,14 +7,16 @@
 
 use std::sync::Arc;
 
-use encointer_node_notee_runtime::{opaque::Block, AccountId, Balance, BlockNumber, Index, Moment};
-use pallet_encointer_bazaar_rpc::{Bazaar, BazaarApi};
-use pallet_encointer_ceremonies_rpc::{Ceremonies, CeremoniesApi};
-pub use sc_rpc_api::DenyUnsafe;
+use jsonrpsee::RpcModule;
+use node_template_runtime::{opaque::Block, AccountId, Balance, Index};
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
+use pallet_encointer_bazaar_rpc::{Bazaar, BazaarApi};
+use pallet_encointer_ceremonies_rpc::{Ceremonies, CeremoniesApi};
+
+pub use sc_rpc_api::DenyUnsafe;
 
 /// Full client dependencies.
 ///
@@ -52,22 +54,21 @@ where
 	<TBackend as sc_client_api::Backend<Block>>::OffchainStorage: 'static,
 {
 	use pallet_encointer_communities_rpc::{Communities, CommunitiesApi};
-	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
-	use substrate_frame_rpc_system::{FullSystem, SystemApi};
+	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
+	use substrate_frame_rpc_system::{System, SystemApiServer};
 
-	let mut io = jsonrpc_core::IoHandler::default();
+	let mut module = RpcModule::new(());
 	let FullDeps { client, pool, backend, offchain_indexing_enabled, deny_unsafe } = deps;
 
-	io.extend_with(SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe)));
+	module.merge(System::new(client.clone(), pool, deny_unsafe).into_rpc())?;
+	module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
 
-	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(client.clone())));
-
-	io.extend_with(BazaarApi::to_delegate(Bazaar::new(client.clone(), deny_unsafe)));
+	module.merge(BazaarApi::to_delegate(Bazaar::new(client.clone(), deny_unsafe)));
 
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed
 	// to call into the runtime.
-	// `io.extend_with(YourRpcTrait::to_delegate(YourRpcStruct::new(ReferenceToClient, ...)));`
+	// `module.merge(YourRpcTrait::to_delegate(YourRpcStruct::new(ReferenceToClient, ...)));`
 
 	match backend.offchain_storage() {
 		Some(storage) => {

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -31,7 +31,7 @@ impl sc_executor::NativeExecutionDispatch for ExecutorDispatch {
 	}
 }
 
-type FullClient =
+pub(crate) type FullClient =
 	sc_service::TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<ExecutorDispatch>>;
 type FullBackend = sc_service::TFullBackend<Block>;
 type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
@@ -82,7 +82,7 @@ pub fn new_partial(
 
 	let (client, backend, keystore_container, task_manager) =
 		sc_service::new_full_parts::<Block, RuntimeApi, _>(
-			&config,
+			config,
 			telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
 			executor,
 		)?;
@@ -237,7 +237,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 				deny_unsafe,
 			};
 
-			Ok(crate::rpc::create_full(deps))
+			crate::rpc::create_full(deps).map_err(Into::into)
 		})
 	};
 
@@ -247,7 +247,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 		keystore: keystore_container.sync_keystore(),
 		task_manager: &mut task_manager,
 		transaction_pool: transaction_pool.clone(),
-		rpc_extensions_builder,
+		rpc_builder: rpc_extensions_builder,
 		backend,
 		system_rpc_tx,
 		config,
@@ -271,7 +271,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 		let aura = sc_consensus_aura::start_aura::<AuraPair, _, _, _, _, _, _, _, _, _, _, _>(
 			StartAuraParams {
 				slot_duration,
-				client: client.clone(),
+				client,
 				select_chain,
 				block_import,
 				proposer_factory,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,8 +11,8 @@ version = "0.8.16"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-serde = { features = ["derive"], optional = true, version = "1.0.136" }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+serde = { features = ["derive"], optional = true, version = "1.0.136" } # added by encointer
 
 # encointer deps
 encointer-primitives = { default-features = false, git = "https://github.com/encointer/pallets", branch = "master" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -39,6 +39,7 @@ pub use frame_support::{
 	},
 	StorageValue,
 };
+pub use frame_system::Call as SystemCall;
 pub use pallet_balances::Call as BalancesCall;
 pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::CurrencyAdapter;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-03-10"
+channel = "nightly-2022-05-31"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy


### PR DESCRIPTION
Changes:
* bump https://github.com/paritytech/substrate/commit/0f3f48962a3ede7f84c0bc4119a8eac08aebd43b, corresponds to polkadot v0.9.23
* bump api-client: we can use the generic signed extra and don't need to hardcode it any more