### PR TITLE
[cli] At block arg for balance, add signer arg for next-phase

### DIFF
--- a/client/dump_account_balances.sh
+++ b/client/dump_account_balances.sh
@@ -1,0 +1,7 @@
+cat accounts_all.txt | while read a
+do
+  BAL=$(../target/release/encointer-client-notee -u wss://kusama.api.encointer.org -p 443 balance $a --cid u0qj92QX9PQ --at 0xcfb07c60aadd57676ce0591678b58511ebd03bdef7385c9690f42e744f1dbff6)
+  # translate Kusama prefix to substrate prefix for easy search
+  ACC=$(subkey inspect $a --network substrate | grep -P '^[\s]+SS58' | sed 's/^ *SS58 Address: *//')
+  echo $a,$ACC,$BAL
+done

--- a/client/py_client/client.py
+++ b/client/py_client/client.py
@@ -177,7 +177,7 @@ class Client:
         return ret.stdout.decode("utf-8").strip()
 
     def claim_reward(self, account, cid, pay_fees_in_cc=False):
-        ret = self.run_cli_command(["claim-reward", account], cid, pay_fees_in_cc)
+        ret = self.run_cli_command(["claim-reward", "--signer", account], cid, pay_fees_in_cc)
         return ret.stdout.decode("utf-8").strip()
 
     def create_business(self, account, cid, ipfs_cid, pay_fees_in_cc=False):

--- a/client/py_client/client.py
+++ b/client/py_client/client.py
@@ -158,11 +158,11 @@ class Client:
         meetups = []
         lines = ret.stdout.decode("utf-8").splitlines()
         while len(lines) > 0:
-            if 'participants are:' in lines.pop(0):
+            if 'participants:' in lines.pop(0):
                 participants = []
                 while len(lines) > 0:
                     l = lines.pop(0)
-                    if 'MeetupRegistry' in l:
+                    if ('MeetupRegistry' in l) or ('total' in l):
                         break
                     participants.append(l.strip())
                 meetups.append(participants)

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -69,9 +69,11 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 	fn signer_arg(self, help: &'b str) -> Self {
 		self.arg(
 			Arg::with_name(SIGNER_ARG)
+				.short("s")
+				.long("signer")
 				.takes_value(true)
-				.required(true)
-				.value_name("SS58")
+				.required(false)
+				.value_name("suri, seed , mnemonic or SS58 in keystore")
 				.help(help),
 		)
 	}

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -1,4 +1,6 @@
 use clap::{App, Arg, ArgMatches};
+use substrate_api_client::Hash;
+use substrate_api_client::FromHexString;
 
 const ACCOUNT_ARG: &'static str = "accountid";
 const SIGNER_ARG: &'static str = "signer";
@@ -14,6 +16,8 @@ const ENDORSEES_ARG: &'static str = "endorsees";
 const TIME_OFFSET_ARG: &'static str = "time-offset";
 const ALL_FLAG: &'static str = "all";
 const TX_PAYMENT_CID_ARG: &'static str = "tx-payment-cid";
+const AT_BLOCK_ARG: &'static str = "at";
+
 
 pub trait EncointerArgs<'b> {
 	fn account_arg(self) -> Self;
@@ -30,6 +34,7 @@ pub trait EncointerArgs<'b> {
 	fn time_offset_arg(self) -> Self;
 	fn all_flag(self) -> Self;
 	fn tx_payment_cid_arg(self) -> Self;
+	fn at_block_arg(self) -> Self;
 }
 
 pub trait EncointerArgsExtractor {
@@ -47,6 +52,7 @@ pub trait EncointerArgsExtractor {
 	fn time_offset_arg(&self) -> Option<i32>;
 	fn all_flag(&self) -> bool;
 	fn tx_payment_cid_arg(&self) -> Option<&str>;
+	fn at_block_arg(&self) -> Option<Hash>;
 }
 
 impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
@@ -196,6 +202,17 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 				.help("cid of the community currency in which tx fees should be paid"),
 		)
 	}
+	fn at_block_arg(self) -> Self {
+		self.arg(
+			Arg::with_name(AT_BLOCK_ARG)
+				.long("at")
+				.global(true)
+				.takes_value(true)
+				.required(false)
+				.value_name("STRING")
+				.help("block hash at which to query"),
+		)
+	}
 }
 
 impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
@@ -250,5 +267,12 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 	}
 	fn tx_payment_cid_arg(&self) -> Option<&str> {
 		self.value_of(TX_PAYMENT_CID_ARG)
+	}
+	fn at_block_arg(&self) -> Option<Hash> {
+		if let Some(hexhashstr)= self.value_of(AT_BLOCK_ARG) {
+			Some(Hash::from_hex(hexhashstr.to_string()).unwrap())
+		} else {
+			None
+		}
 	}
 }

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -269,10 +269,6 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 		self.value_of(TX_PAYMENT_CID_ARG)
 	}
 	fn at_block_arg(&self) -> Option<Hash> {
-		if let Some(hexhashstr) = self.value_of(AT_BLOCK_ARG) {
-			Some(Hash::from_hex(hexhashstr.to_string()).unwrap())
-		} else {
-			None
-		}
+		self.value_of(AT_BLOCK_ARG).map(|hex| Hash::from_hex(hex.to_string()).unwrap())
 	}
 }

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -1,6 +1,5 @@
 use clap::{App, Arg, ArgMatches};
-use substrate_api_client::Hash;
-use substrate_api_client::FromHexString;
+use substrate_api_client::{FromHexString, Hash};
 
 const ACCOUNT_ARG: &'static str = "accountid";
 const SIGNER_ARG: &'static str = "signer";
@@ -17,7 +16,6 @@ const TIME_OFFSET_ARG: &'static str = "time-offset";
 const ALL_FLAG: &'static str = "all";
 const TX_PAYMENT_CID_ARG: &'static str = "tx-payment-cid";
 const AT_BLOCK_ARG: &'static str = "at";
-
 
 pub trait EncointerArgs<'b> {
 	fn account_arg(self) -> Self;
@@ -271,7 +269,7 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 		self.value_of(TX_PAYMENT_CID_ARG)
 	}
 	fn at_block_arg(&self) -> Option<Hash> {
-		if let Some(hexhashstr)= self.value_of(AT_BLOCK_ARG) {
+		if let Some(hexhashstr) = self.value_of(AT_BLOCK_ARG) {
 			Some(Hash::from_hex(hexhashstr.to_string()).unwrap())
 		} else {
 			None

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1469,7 +1469,10 @@ fn new_claim_for(
 	claim.encode()
 }
 
-fn get_community_identifiers(api: &Api, maybe_at: Option<Hash>) -> Option<Vec<CommunityIdentifier>> {
+fn get_community_identifiers(
+	api: &Api,
+	maybe_at: Option<Hash>,
+) -> Option<Vec<CommunityIdentifier>> {
 	api.get_storage_value("EncointerCommunities", "CommunityIdentifiers", maybe_at)
 		.unwrap()
 }
@@ -1756,8 +1759,11 @@ impl ToString for BazaarCalls {
 fn set_api_extrisic_params_builder(api: Api, tx_payment_cid_arg: Option<&str>) -> Api {
 	let mut tx_params = CommunityCurrencyTipExtrinsicParamsBuilder::new().tip(0);
 	if let Some(tx_payment_cid) = tx_payment_cid_arg {
-		tx_params = tx_params
-			.tip(CommunityCurrencyTip::new(0).of_community(verify_cid(&api, tx_payment_cid, None)));
+		tx_params = tx_params.tip(CommunityCurrencyTip::new(0).of_community(verify_cid(
+			&api,
+			tx_payment_cid,
+			None,
+		)));
 	}
 	api.set_extrinsic_params_builder(tx_params)
 }

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -109,7 +109,7 @@ pub fn ensure_payment(api: &Api, xt: &str, tx_payment_cid: Option<&str>) {
 }
 
 fn ensure_payment_cc(api: &Api, cid_str: &str) {
-	let cid = verify_cid(&api, cid_str);
+	let cid = verify_cid(&api, cid_str, None);
 	match api
 		.get_storage_double_map::<_, _, BalanceEntry<BlockNumber>>(
 			"EncointerBalances",

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -216,7 +216,12 @@ pub mod keys {
 		debug!("getting pair for {}", account);
 		match &account[..2] {
 			"//" => sr25519::AppPair::from_string(account, None).unwrap(),
+			"0x" => sr25519::AppPair::from_string_with_seed(account, None).unwrap().0,
 			_ => {
+				if sr25519::Public::from_ss58check(account).is_err() {
+					// could be mnemonic phrase
+					return sr25519::AppPair::from_string_with_seed(account, None).unwrap().0
+				}
 				debug!("fetching from keystore at {}", &KEYSTORE_PATH);
 				// open store without password protection
 				let store = LocalKeystore::open(PathBuf::from(&KEYSTORE_PATH), None)

--- a/client/test-data/leu.zuerich.V1.json
+++ b/client/test-data/leu.zuerich.V1.json
@@ -8,11 +8,11 @@
       "url": "https://leu.zuerich"
     },
     "bootstrappers": [
+      "5EEh6sjZjxaMkm3vn7nKib9ciuxAGQRc4uosmuDa6vuTgfDp",
       "5HTJ7uvBZgp4VcXsWqMSz5r6C5vCzfodB3oYgJikmbesmGAQ",
       "5ELFUAhU3qNijJeWi9vDHR8Q8GTmdeQ7vCmhwHYBTKLfkiVt",
       "5F4WftsrF1Wqtbm7kK5FRRrvUf4w8syazFJH3Mz5JkdcZqs7",
       "5Cm38saAbnwrxvnGCp4Pqff5K3rKy4awYQnrdqDeHfvW2ZUM",
-      "5EEh6sjZjxaMkm3vn7nKib9ciuxAGQRc4uosmuDa6vuTgfDp",
       "5FvNKkMDRb8pBsXfxRBphY9ZmkkCNUHWnq5Dpw7hKpvBU1L4",
       "5F23TQ7ReiDj3fDKra9QwWSy94XAsmF4AKVdBFLmn4bmUYAD",
       "5C86aoJWYuuHxYsi5d74ddJ6tYNhwnLeXHe5qqBWui2cmmPh",
@@ -20,7 +20,7 @@
       "5E9bTMkC6tJUKBxw7Jz9qQ1t1yVAU2j3ctXbsE7JVccfaK4X"
     ],
     "demurrage_halving_blocks": 2628000,
-    "ceremony_income": 1077
+    "ceremony_income": 22
   },
   "features": [
     {

--- a/client/voucher.py
+++ b/client/voucher.py
@@ -21,7 +21,7 @@ def main(issuer, cid, network, n):
         for i in range(n):
             voucher_token = b58encode(secrets.token_bytes(24)).decode()
             voucher_uri = f"//{batch_token}/{voucher_token}"
-            f.write(voucher_uri)
+            f.write(voucher_uri + "\n")
             print(f"generating voucher {i}: {voucher_uri}")
             payload = f"encointer-voucher\nV2.0\n{voucher_uri}\n{cid}\n{network}\n{issuer}"
             img = qrcode.make(payload)


### PR DESCRIPTION
new cli arguments
* `--at` to specify block hash at which to query balance 
* `--signer` to specify extrinsic signer by SS58, suri, seed or mnemonic

also, a helper script has been added for reference to dump balances for a list of accounts

the Leu config changes are a bit alien to this PR but they are related to the need for the new arguments. so leaving that commit in here

usage to query historic balance
```
../target/release/encointer-client-notee -u wss://kusama.api.encointer.org -p 443 balance 5Cm38saAbnwrxvnGCp4Pqff5K3rKy4awYQnrdqDeHfvW2ZUM --cid u0qj92QX9PQ --at 0xcfb07c60aadd57676ce0591678b58511ebd03bdef7385c9690f42e744f1dbff6
```
