### PR TITLE
bump v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-client-notee"
-version = "0.8.8"
+version = "1.2.0"
 dependencies = [
  "clap 2.34.0",
  "clap-nested",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-node-notee"
-version = "0.8.8"
+version = "1.2.0"
 dependencies = [
  "clap 3.1.18",
  "encointer-node-notee-runtime",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-node-notee-runtime"
-version = "0.8.17"
+version = "1.2.18"
 dependencies = [
  "encointer-balances-tx-payment",
  "encointer-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1490,8 +1490,8 @@ dependencies = [
 
 [[package]]
 name = "encointer-ceremonies-assignment"
-version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -1530,8 +1530,8 @@ dependencies = [
 
 [[package]]
 name = "encointer-meetup-validation"
-version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -1643,8 +1643,8 @@ dependencies = [
 
 [[package]]
 name = "encointer-primitives"
-version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "bs58",
  "concat-arrays",
@@ -1664,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "encointer-rpc"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "jsonrpsee",
  "thiserror",
@@ -1703,8 +1703,8 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
 name = "ep-core"
-version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -4456,8 +4456,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-balances"
-version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4476,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4493,7 +4493,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4512,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4522,8 +4522,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies"
-version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-meetup-validation",
@@ -4547,8 +4547,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
-version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4566,8 +4566,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
-version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4577,8 +4577,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities"
-version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4596,8 +4596,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities-rpc"
-version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4615,8 +4615,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
-version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "encointer-primitives",
  "sp-api",
@@ -4626,7 +4626,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-scheduler"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#2c5cb5d287adeec48cb49ab7fbf61dbe5721286c"
+source = "git+https://github.com/encointer/pallets?branch=master#588953ebf300e51e1d7a752be1a72997dc526cf9"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Additional CLI usage options are available and may be shown by running `./target
 Join our testnet as a full node with 
 
 ```bash
-./target/release/encointer-node-notee --chain gesellv4SpecRaw.json --name giveyournodeaname
+RUST_LOG=INFO,parity_ws=WARN,sc_basic_authorship=warn,aura=warn,encointer=debug
+./target/release/encointer-node-notee --chain gesellv4SpecRaw.json --enable-offchain-indexing true --rpc-cors all
 ```
 
 ## CLI client

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -2,8 +2,8 @@
 name = "encointer-client-notee"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2021"
-#keep with node version
-version = "0.8.8"
+#keep with node version. major, minor and patch
+version = "1.2.0"
 
 [dependencies]
 clap = "2.33"

--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -5,6 +5,7 @@ Demonstrate the bootstrapping of an Encointer community on a *dev* chain.
 start node with
   ../target/release/encointer-node-notee --dev --tmp --ws-port 9945 --enable-offchain-indexing true --rpc-methods unsafe
 
+or start parachain with  
 then run this script
   ./bootstrap_demo_community.py --port 9945
 

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -42,7 +42,7 @@ from py_client.client import Client, ExtrinsicFeePaymentImpossible, ExtrinsicWro
 from py_client.ipfs import Ipfs, ASSETS_PATH
 
 KEYSTORE_PATH = './my_keystore'
-NUMBER_OF_LOCATIONS = 10
+NUMBER_OF_LOCATIONS = 100
 MAX_POPULATION = 10 * NUMBER_OF_LOCATIONS
 NUMBER_OF_ENDORSEMENTS_PER_REGISTRATION = 10
 

--- a/client/phase.py
+++ b/client/phase.py
@@ -9,7 +9,7 @@ useful for benchmarking bot communities in a local setup
 
 import subprocess
 import click
-import substrateinterface
+from substrateinterface import SubstrateInterface
 import json
 from py_client.client import Client
 from py_client.helpers import set_local_or_remote_chain
@@ -34,7 +34,7 @@ def main(remote_chain, client, port, idle_blocks):
     patience = idle_blocks
     with open('typedefs.json') as f:
         custom_type_registry = json.load(f)
-    substrate = substrateinterface.SubstrateInterface(
+    substrate = SubstrateInterface(
         url= f"wss://gesell.encointer.org:{443}" if localhost is not None else f"ws://127.0.0.1:{port}",
         ss58_format=42,
         type_registry_preset='substrate-node-template',

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,8 +7,9 @@ homepage = "https://encointer.org"
 license = "GPL-3.0"
 name = "encointer-node-notee"
 repository = "https://github.com/encointer/encointer-node"
-#keep with client version
-version = "0.8.8"
+# keep with client version
+# follow parachain major and minor revision
+version = "1.2.0"
 
 [[bin]]
 name = "encointer-node-notee"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,7 +7,7 @@ name = "encointer-node-notee-runtime"
 repository = "https://github.com/encointer/encointer-node/"
 # minor revision must match node/client
 # patch revision must match runtime spec_version
-version = "0.8.17"
+version = "1.2.18"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the runtime specification. A full node will not attempt to use its native
 	//   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
-	spec_version: 17,
+	spec_version: 18,
 	impl_version: 0,
 
 	apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
* bump pallet deps to tagged 1.2.0
* bump crate versions to follow parachain versioning - easier to guess cli client compatibility. and node will furthermore be a slave of parachain anyway. getting the bumps first, but versions defined by parachain