### PR TITLE
Adjust CLI to runtime v8

### DIFF
--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -118,9 +118,9 @@ def fee_payment_transfers(client, cid):
         exit(1)
 
 
-def claim_rewards(client, cid, account, pay_fees_in_cc=False):
+def claim_rewards(client, cid, account, meetup_index=None, all_upto=None, pay_fees_in_cc=False):
     print("Claiming rewards")
-    client.claim_reward(account, cid, pay_fees_in_cc=pay_fees_in_cc)
+    client.claim_reward(account, cid, meetup_index=meetup_index, all_upto=all_upto, pay_fees_in_cc=pay_fees_in_cc)
     client.await_block(3)
 
 

--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -118,9 +118,9 @@ def fee_payment_transfers(client, cid):
         exit(1)
 
 
-def claim_rewards(client, cid, account, meetup_index=None, all_upto=None, pay_fees_in_cc=False):
+def claim_rewards(client, cid, account, meetup_index=None, all=False, pay_fees_in_cc=False):
     print("Claiming rewards")
-    client.claim_reward(account, cid, meetup_index=meetup_index, all_upto=all_upto, pay_fees_in_cc=pay_fees_in_cc)
+    client.claim_reward(account, cid, meetup_index=meetup_index, all=all, pay_fees_in_cc=pay_fees_in_cc)
     client.await_block(3)
 
 
@@ -193,16 +193,6 @@ def main(ipfs_local, client, port, spec_file):
         print("claim_reward fees were not refunded if paid in native currency")
         exit(1)
 
-    register_participants_and_perform_meetup(client, cid, accounts)
-    client.next_phase()
-    client.await_block(1)
-    claim_rewards(client, cid, account1, pay_fees_in_cc=True)
-    balance1 = client.balance(account1, cid=cid)
-    balance2 = client.balance(account2, cid=cid)
-    if(not balance1 == balance2):
-        print("claim_reward fees were not refunded if paid in cc")
-        exit(1)
-
     print(f'Balances for new community with cid: {cid}.')
     bal = [client.balance(a, cid=cid) for a in accounts]
     [print(f'Account balance for {ab[0]} is {ab[1]}.') for ab in list(zip(accounts, bal))]
@@ -215,6 +205,16 @@ def main(ipfs_local, client, port, spec_file):
     print(rep)
     if not len(rep) > 0:
         print("no reputation gained")
+        exit(1)
+        
+    register_participants_and_perform_meetup(client, cid, accounts)
+    client.next_phase()
+    client.await_block(1)
+    claim_rewards(client, cid, account1, pay_fees_in_cc=True)
+    balance1 = client.balance(account1, cid=cid)
+    balance2 = client.balance(account2, cid=cid)
+    if(not balance1 == balance2):
+        print("claim_reward fees were not refunded if paid in cc")
         exit(1)
 
     fee_payment_transfers(client, cid)

--- a/client/py_client/client.py
+++ b/client/py_client/client.py
@@ -176,8 +176,14 @@ class Client:
         ret = self.run_cli_command(["list-attestees"], cid=cid)
         return ret.stdout.decode("utf-8").strip()
 
-    def claim_reward(self, account, cid, pay_fees_in_cc=False):
-        ret = self.run_cli_command(["claim-reward", "--signer", account], cid, pay_fees_in_cc)
+    def claim_reward(self, account, cid, meetup_index=None, all_upto=None, pay_fees_in_cc=False):
+        optional_args = []
+        if meetup_index:
+            optional_args += ["--meetup-index", str(meetup_index)]
+        if all_upto:
+            optional_args += ["--all-upto", str(all_upto)]
+
+        ret = self.run_cli_command(["claim-reward", "--signer", account] + optional_args, cid, pay_fees_in_cc)
         return ret.stdout.decode("utf-8").strip()
 
     def create_business(self, account, cid, ipfs_cid, pay_fees_in_cc=False):

--- a/client/py_client/client.py
+++ b/client/py_client/client.py
@@ -176,12 +176,12 @@ class Client:
         ret = self.run_cli_command(["list-attestees"], cid=cid)
         return ret.stdout.decode("utf-8").strip()
 
-    def claim_reward(self, account, cid, meetup_index=None, all_upto=None, pay_fees_in_cc=False):
+    def claim_reward(self, account, cid, meetup_index=None, all=False, pay_fees_in_cc=False):
         optional_args = []
         if meetup_index:
             optional_args += ["--meetup-index", str(meetup_index)]
-        if all_upto:
-            optional_args += ["--all-upto", str(all_upto)]
+        if all:
+            optional_args += ["--all"]
 
         ret = self.run_cli_command(["claim-reward", "--signer", account] + optional_args, cid, pay_fees_in_cc)
         return ret.stdout.decode("utf-8").strip()

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -16,7 +16,6 @@ const TIME_OFFSET_ARG: &'static str = "time-offset";
 const ALL_FLAG: &'static str = "all";
 const TX_PAYMENT_CID_ARG: &'static str = "tx-payment-cid";
 const MEETUP_INDEX_ARG: &'static str = "meetup-index";
-const ALL_UPTO_ARG: &'static str = "all-upto";
 const AT_BLOCK_ARG: &'static str = "at";
 
 pub trait EncointerArgs<'b> {
@@ -35,7 +34,6 @@ pub trait EncointerArgs<'b> {
 	fn all_flag(self) -> Self;
 	fn tx_payment_cid_arg(self) -> Self;
 	fn meetup_index_arg(self) -> Self;
-	fn all_upto_arg(self) -> Self;
 	fn at_block_arg(self) -> Self;
 }
 
@@ -55,7 +53,6 @@ pub trait EncointerArgsExtractor {
 	fn all_flag(&self) -> bool;
 	fn tx_payment_cid_arg(&self) -> Option<&str>;
 	fn meetup_index_arg(&self) -> Option<u64>;
-	fn all_upto_arg(&self) -> Option<u64>;
 	fn at_block_arg(&self) -> Option<Hash>;
 }
 
@@ -216,18 +213,8 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 				.takes_value(true)
 				.required(false)
 				.value_name("MEETUP_INDEX")
+				.conflicts_with(ALL_FLAG)
 				.help("the meetup index for which to claim rewards"),
-		)
-	}
-
-	fn all_upto_arg(self) -> Self {
-		self.arg(
-			Arg::with_name(ALL_UPTO_ARG)
-				.long("all-upto")
-				.takes_value(true)
-				.required(false)
-				.value_name("ALL_UPTO")
-				.help("claim rewards for meetup indexes 1..=all-upto"),
 		)
 	}
 
@@ -299,9 +286,6 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 	}
 	fn meetup_index_arg(&self) -> Option<u64> {
 		self.value_of(MEETUP_INDEX_ARG).map(|v| v.parse().unwrap())
-	}
-	fn all_upto_arg(&self) -> Option<u64> {
-		self.value_of(ALL_UPTO_ARG).map(|v| v.parse().unwrap())
 	}
 	fn at_block_arg(&self) -> Option<Hash> {
 		self.value_of(AT_BLOCK_ARG).map(|hex| Hash::from_hex(hex.to_string()).unwrap())

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -15,6 +15,8 @@ const ENDORSEES_ARG: &'static str = "endorsees";
 const TIME_OFFSET_ARG: &'static str = "time-offset";
 const ALL_FLAG: &'static str = "all";
 const TX_PAYMENT_CID_ARG: &'static str = "tx-payment-cid";
+const MEETUP_INDEX_ARG: &'static str = "meetup-index";
+const ALL_UPTO_ARG: &'static str = "all-upto";
 const AT_BLOCK_ARG: &'static str = "at";
 
 pub trait EncointerArgs<'b> {
@@ -32,6 +34,8 @@ pub trait EncointerArgs<'b> {
 	fn time_offset_arg(self) -> Self;
 	fn all_flag(self) -> Self;
 	fn tx_payment_cid_arg(self) -> Self;
+	fn meetup_index_arg(self) -> Self;
+	fn all_upto_arg(self) -> Self;
 	fn at_block_arg(self) -> Self;
 }
 
@@ -50,6 +54,8 @@ pub trait EncointerArgsExtractor {
 	fn time_offset_arg(&self) -> Option<i32>;
 	fn all_flag(&self) -> bool;
 	fn tx_payment_cid_arg(&self) -> Option<&str>;
+	fn meetup_index_arg(&self) -> Option<u64>;
+	fn all_upto_arg(&self) -> Option<u64>;
 	fn at_block_arg(&self) -> Option<Hash>;
 }
 
@@ -202,6 +208,28 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 				.help("cid of the community currency in which tx fees should be paid"),
 		)
 	}
+	fn meetup_index_arg(self) -> Self {
+		self.arg(
+			Arg::with_name(MEETUP_INDEX_ARG)
+				.long("meetup-index")
+				.takes_value(true)
+				.required(false)
+				.value_name("MEETUP_INDEX")
+				.help("the meetup index for which to claim rewards"),
+		)
+	}
+
+	fn all_upto_arg(self) -> Self {
+		self.arg(
+			Arg::with_name(MEETUP_INDEX_ARG)
+				.long("all-upto")
+				.takes_value(true)
+				.required(false)
+				.value_name("MEETUP_INDEX")
+				.help("claim rewards for meetup indexes 1..=all-upto"),
+		)
+	}
+
 	fn at_block_arg(self) -> Self {
 		self.arg(
 			Arg::with_name(AT_BLOCK_ARG)
@@ -267,6 +295,12 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 	}
 	fn tx_payment_cid_arg(&self) -> Option<&str> {
 		self.value_of(TX_PAYMENT_CID_ARG)
+	}
+	fn meetup_index_arg(&self) -> Option<u64> {
+		self.value_of(MEETUP_INDEX_ARG).map(|v| v.parse().unwrap())
+	}
+	fn all_upto_arg(&self) -> Option<u64> {
+		self.value_of(ALL_UPTO_ARG).map(|v| v.parse().unwrap())
 	}
 	fn at_block_arg(&self) -> Option<Hash> {
 		self.value_of(AT_BLOCK_ARG).map(|hex| Hash::from_hex(hex.to_string()).unwrap())

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -78,7 +78,8 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 				.takes_value(true)
 				.required(false)
 				.value_name("suri, seed , mnemonic or SS58 in keystore")
-				.help(help),
+				.help(help)
+				.conflicts_with(MEETUP_INDEX_ARG),
 		)
 	}
 

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -221,11 +221,11 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 
 	fn all_upto_arg(self) -> Self {
 		self.arg(
-			Arg::with_name(MEETUP_INDEX_ARG)
+			Arg::with_name(ALL_UPTO_ARG)
 				.long("all-upto")
 				.takes_value(true)
 				.required(false)
-				.value_name("MEETUP_INDEX")
+				.value_name("ALL_UPTO")
 				.help("claim rewards for meetup indexes 1..=all-upto"),
 		)
 	}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1065,7 +1065,7 @@ fn main() {
                                 }
                                 let meetup_count = api
                                 .get_storage_map("EncointerCeremonies", "MeetupCount", (cid, cindex), None)
-                                .unwrap().unwrap();
+                                .unwrap().unwrap_or(0u64);
                                 let calls: Vec<_> = (1u64..=meetup_count)
                                 .map(|idx| compose_call!(
                                     api.metadata,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1057,8 +1057,6 @@ fn main() {
                             let tx_payment_cid_arg = matches.tx_payment_cid_arg();
                             let meetup_index_arg = matches.meetup_index_arg();
                             let all_upto_arg = matches.all_upto_arg();
-                            
-
                             api = set_api_extrisic_params_builder(api, tx_payment_cid_arg);
 
                             if let Some(all_upto) = all_upto_arg {


### PR DESCRIPTION
* Closes #241
* Closes #242 

introduces a `--meetup-index` and `--all` flag for `claim-rewards`
and allows registering in attesting phase
and adds optional `--signer` arg to `register-participant`