### PR TITLE
[Client] use new extrinsic: `attest_attendees` instead of old `attest_claims`

### DIFF
--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -30,16 +30,11 @@ TEST_LOCATIONS_MEDITERRANEAN = 'test-locations-mediterranean.json'
 
 def perform_meetup(client, cid):
     print('Starting meetup...')
-    print('Creating claims...')
-    vote = len(accounts)
-    claim1 = client.new_claim(account1, vote, cid)
-    claim2 = client.new_claim(account2, vote, cid)
-    claim3 = client.new_claim(account3, vote, cid)
 
-    print('Sending claims of attestees to chain...')
-    client.attest_claims(account1, [claim2, claim3])
-    client.attest_claims(account2, [claim1, claim3])
-    client.attest_claims(account3, [claim1, claim2])
+    print('Attest other attendees...')
+    client.attest_attendees(account1, cid, [account2, account3])
+    client.attest_attendees(account2, cid, [account1, account3])
+    client.attest_attendees(account3, cid, [account1, account2])
 
 
 def update_spec_with_cid(file, cid):
@@ -186,13 +181,17 @@ def main(ipfs_local, client, port, spec_file):
     faucet(client, cid)
 
     register_participants_and_perform_meetup(client, cid, accounts)
-    client.next_phase()
-    client.await_block(1)
+
     balance = client.balance(account1)
+
+    print("Claiming early rewards")
     claim_rewards(client, cid, account1)
     if(not balance == client.balance(account1)):
         print("claim_reward fees were not refunded if paid in native currency")
         exit(1)
+
+    client.next_phase()
+    client.await_block(1)
 
     print(f'Balances for new community with cid: {cid}.')
     bal = [client.balance(a, cid=cid) for a in accounts]

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -312,12 +312,10 @@ def perform_meetup(client: Client, meetup, cid):
     n = len(meetup)
     print(f'Performing meetup with {n} participants')
 
-    claims = [client.new_claim(p, n, cid) for p in meetup]
-
     for p_index in range(len(meetup)):
         attestor = meetup[p_index]
-        attestees_claims = claims[:p_index] + claims[p_index + 1:]
-        client.attest_claims(attestor, attestees_claims)
+        attendees = meetup[:p_index] + meetup[p_index + 1:]
+        client.attest_attendees(attestor, cid, attendees)
 
 
 if __name__ == '__main__':

--- a/client/py_client/client.py
+++ b/client/py_client/client.py
@@ -171,8 +171,8 @@ class Client:
                 meetups.append(participants)
         return meetups
 
-    def attest_claims(self, account, claims, pay_fees_in_cc=False):
-        ret = self.run_cli_command(["attest-claims", account] + claims, pay_fees_in_cc=pay_fees_in_cc)
+    def attest_attendees(self, account, cid, attendees, pay_fees_in_cc=False):
+        ret = self.run_cli_command(["attest-attendees", account] + attendees, cid=cid, pay_fees_in_cc=pay_fees_in_cc)
         ensure_clean_exit(ret.returncode)
 
     def list_attestees(self, cid):

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -5,7 +5,7 @@ const ACCOUNT_ARG: &'static str = "accountid";
 const SEED_ARG: &'static str = "seed";
 const SIGNER_ARG: &'static str = "signer";
 const CID_ARG: &'static str = "cid";
-const CLAIMS_ARG: &'static str = "claims";
+const ATTESTEES_ARG: &'static str = "attestees";
 const CEREMONY_INDEX_ARG: &'static str = "ceremony-index";
 const IPFS_CID_ARG: &'static str = "ipfs-cid";
 const BOOTSTRAPPER_ARG: &'static str = "bootstrapper";
@@ -25,7 +25,7 @@ pub trait EncointerArgs<'b> {
 	fn seed_arg(self) -> Self;
 	fn signer_arg(self, help: &'b str) -> Self;
 	fn optional_cid_arg(self) -> Self;
-	fn claims_arg(self) -> Self;
+	fn attestees_arg(self) -> Self;
 	fn ceremony_index_arg(self) -> Self;
 	fn ipfs_cid_arg(self) -> Self;
 	fn bootstrapper_arg(self) -> Self;
@@ -46,7 +46,7 @@ pub trait EncointerArgsExtractor {
 	fn seed_arg(&self) -> Option<&str>;
 	fn signer_arg(&self) -> Option<&str>;
 	fn cid_arg(&self) -> Option<&str>;
-	fn claims_arg(&self) -> Option<Vec<&str>>;
+	fn attestees_arg(&self) -> Option<Vec<&str>>;
 	fn ceremony_index_arg(&self) -> Option<i32>;
 	fn ipfs_cid_arg(&self) -> Option<&str>;
 	fn bootstrapper_arg(&self) -> Option<&str>;
@@ -108,9 +108,9 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 		)
 	}
 
-	fn claims_arg(self) -> Self {
+	fn attestees_arg(self) -> Self {
 		self.arg(
-			Arg::with_name(CLAIMS_ARG)
+			Arg::with_name(ATTESTEES_ARG)
 				.takes_value(true)
 				.required(true)
 				.multiple(true)
@@ -274,8 +274,8 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 		self.value_of(CID_ARG)
 	}
 
-	fn claims_arg(&self) -> Option<Vec<&str>> {
-		self.values_of(CLAIMS_ARG).map(|c| c.collect())
+	fn attestees_arg(&self) -> Option<Vec<&str>> {
+		self.values_of(ATTESTEES_ARG).map(|c| c.collect())
 	}
 
 	fn ceremony_index_arg(&self) -> Option<i32> {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-05-31"
+channel = "nightly-2022-11-09"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy


### PR DESCRIPTION
I did this to debug the early payout bug introduced with the app, see: https://github.com/encointer/pallets/issues/278.

However, this will be the way that we will run the bootstrapping scripts anyhow in the future, as the old `attest_claims` extrinsic will be removed.