### PR TITLE
fix storage leak; bump runtime spec version and binary patch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-client-notee"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "clap 2.34.0",
  "clap-nested",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-node-notee"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "clap 3.1.18",
  "encointer-balances-tx-payment-rpc",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-node-notee-runtime"
-version = "1.3.20"
+version = "1.3.21"
 dependencies = [
  "encointer-balances-tx-payment",
  "encointer-balances-tx-payment-rpc-runtime-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,7 +1484,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-balances-tx-payment-rpc-runtime-api",
  "encointer-primitives",
@@ -1524,7 +1524,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "encointer-ceremonies-assignment"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -1579,7 +1579,7 @@ dependencies = [
 [[package]]
 name = "encointer-meetup-validation"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -1695,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "encointer-primitives"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "bs58",
  "crc",
@@ -1714,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "encointer-rpc"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "jsonrpsee",
  "thiserror",
@@ -1754,7 +1754,7 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 [[package]]
 name = "ep-core"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -4513,7 +4513,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-balances"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4532,7 +4532,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4549,7 +4549,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-meetup-validation",
@@ -4604,7 +4604,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4623,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4634,7 +4634,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4653,7 +4653,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4672,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-primitives",
  "sp-api",
@@ -4682,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-scheduler"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#9ee44a459f4b79bb3c722d27f9585000901e3e80"
+source = "git+https://github.com/encointer/pallets?branch=master#6f5adcdfe8fef0acc42da4ae9ca29b2c50ed634b"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -8479,7 +8479,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -3,7 +3,7 @@ name = "encointer-client-notee"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2021"
 #keep with node version. major, minor and patch
-version = "1.3.0"
+version = "1.3.1"
 
 [dependencies]
 clap = "2.33"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,7 +9,7 @@ name = "encointer-node-notee"
 repository = "https://github.com/encointer/encointer-node"
 # keep with client version
 # follow parachain major and minor revision
-version = "1.3.0"
+version = "1.3.1"
 
 [[bin]]
 name = "encointer-node-notee"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,7 +7,7 @@ name = "encointer-node-notee-runtime"
 repository = "https://github.com/encointer/encointer-node/"
 # minor revision must match node/client
 # patch revision must match runtime spec_version
-version = "1.3.20"
+version = "1.3.21"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("encointer-node-notee"),
 	impl_name: create_runtime_str!("encointer-node-notee"),
 	authoring_version: 0,
-	spec_version: 20,
+	spec_version: 21,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,


### PR DESCRIPTION
* Includes https://github.com/encointer/pallets/pull/285