### PR TITLE
Make demurrage computation sound; bump pallets and versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-client-notee"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "clap 2.34.0",
  "clap-nested",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-node-notee"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "clap 3.1.18",
  "encointer-balances-tx-payment-rpc",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-node-notee-runtime"
-version = "1.3.22"
+version = "1.3.23"
 dependencies = [
  "encointer-balances-tx-payment",
  "encointer-balances-tx-payment-rpc-runtime-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,7 +1484,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-balances-tx-payment-rpc-runtime-api",
  "encointer-primitives",
@@ -1524,7 +1524,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "encointer-ceremonies-assignment"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -1579,7 +1579,7 @@ dependencies = [
 [[package]]
 name = "encointer-meetup-validation"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -1695,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "encointer-primitives"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "bs58",
  "crc",
@@ -1714,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "encointer-rpc"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "jsonrpsee",
  "thiserror",
@@ -1754,7 +1754,7 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 [[package]]
 name = "ep-core"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -4513,7 +4513,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-balances"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4532,7 +4532,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4549,7 +4549,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-meetup-validation",
@@ -4604,7 +4604,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4623,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4634,7 +4634,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4653,7 +4653,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4672,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "sp-api",
@@ -4682,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-scheduler"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -3,7 +3,7 @@ name = "encointer-client-notee"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2021"
 #keep with node version. major, minor and patch
-version = "1.3.2"
+version = "1.3.3"
 
 [dependencies]
 clap = "2.33"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,9 +7,11 @@ homepage = "https://encointer.org"
 license = "GPL-3.0"
 name = "encointer-node-notee"
 repository = "https://github.com/encointer/encointer-node"
-# keep with client version
-# follow parachain major and minor revision
-version = "1.3.2"
+# Note the following for the versioning:
+#   * Align minor version with the runtime.
+#   * Bump patch version for new releases, and make it the release tag.
+#   * The client should follow this version.
+version = "1.3.3"
 
 [[bin]]
 name = "encointer-node-notee"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,7 +7,7 @@ name = "encointer-node-notee-runtime"
 repository = "https://github.com/encointer/encointer-node/"
 # minor revision must match node/client
 # patch revision must match runtime spec_version
-version = "1.3.22"
+version = "1.3.23"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("encointer-node-notee"),
 	impl_name: create_runtime_str!("encointer-node-notee"),
 	authoring_version: 0,
-	spec_version: 22,
+	spec_version: 23,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,


### PR DESCRIPTION
This includes the important PR to prevent demurrage from overflowing: https://github.com/encointer/pallets/pull/298