### PR TITLE
Add JsonrpseeClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,6 +2039,7 @@ dependencies = [
  "sp-runtime",
  "substrate-api-client",
  "substrate-client-keystore",
+ "tokio",
 ]
 
 [[package]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,6 +14,7 @@ geojson = "0.22.2"
 hex = "0.4.3"
 log = "0.4.14"
 serde_json = "1.0.79"
+tokio = { version = "1.24", features = ["rt-multi-thread", "macros", "time"] }
 
 # local deps
 encointer-api-client-extension = { path = "./encointer-api-client-extension" }

--- a/client/encointer-api-client-extension/src/lib.rs
+++ b/client/encointer-api-client-extension/src/lib.rs
@@ -1,7 +1,7 @@
 use extrinsic_params::CommunityCurrencyTipExtrinsicParams;
 use substrate_api_client::{
 	ac_primitives::{Config, ExtrinsicSigner, SubstrateKitchensinkConfig, WithExtrinsicParams},
-	rpc::WsRpcClient,
+	rpc::JsonrpseeClient,
 };
 
 pub use encointer_node_notee_runtime::Runtime;
@@ -12,7 +12,7 @@ pub type EncointerConfig = WithExtrinsicParams<
 	CommunityCurrencyTipExtrinsicParams<SubstrateKitchensinkConfig>,
 >;
 
-pub type Api = substrate_api_client::Api<EncointerConfig, WsRpcClient>;
+pub type Api = substrate_api_client::Api<EncointerConfig, JsonrpseeClient>;
 
 pub type ParentchainExtrinsicSigner = ExtrinsicSigner<SubstrateKitchensinkConfig>;
 pub type ExtrinsicAddress = <EncointerConfig as Config>::Address;

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -71,7 +71,7 @@ use substrate_api_client::{
 	ac_primitives::{Bytes, SignExtrinsic},
 	api::error::Error as ApiClientError,
 	extrinsic::BalancesExtrinsics,
-	rpc::{Request, WsRpcClient},
+	rpc::{JsonrpseeClient, Request},
 	GetAccountInformation, GetBalance, GetChainInfo, GetStorage, GetTransactionPayment,
 	Result as ApiResult, SubmitAndWatch, SubscribeEvents, XtStatus,
 };
@@ -91,7 +91,8 @@ mod exit_code {
 	pub const NO_CID_SPECIFIED: i32 = 70;
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	Commander::new()
@@ -1574,7 +1575,7 @@ fn get_chain_api(matches: &ArgMatches<'_>) -> Api {
 		matches.value_of("node-port").unwrap()
 	);
 	debug!("connecting to {}", url);
-	let client = WsRpcClient::new(&url).expect("node URL is incorrect");
+	let client = JsonrpseeClient::new(&url).expect("node URL is incorrect");
 	Api::new(client).unwrap()
 }
 


### PR DESCRIPTION
Might be worth to consider.

Bootstrap community with Jsonrpsee:
```
2023-06-14 12:16:12 ✨ Imported #48 (0x3670…981a)
2023-06-14 12:16:12 Accepting new connection 1/100
2023-06-14 12:16:14 💤 Idle (0 peers), best: #48 (0x3670…981a), finalized #46 (0x9bcc…ca2b), ⬇ 0 ⬆ 0
2023-06-14 12:16:18 🙌 Starting consensus session on top of parent 0x367024e781f983340c1e417593b45abf84780d631b93c4b09644e1e6a899981a
2023-06-14 12:16:18 🎁 Prepared block for proposing at 49 (0 ms) [hash: 0x19f2f067b823cb5165699fe5616437ea4046b6d23feff5345e1261f0038f7603; parent_hash: 0x3670…981a; extrinsics (2): [0x1340…fe70, 0x7c98…ba87]]
2023-06-14 12:16:18 🔖 Pre-sealed block for proposal at 49. Hash now 0x9419828d463b8d142883524347f42594bfc636c4d86d4de66a0c2584bd5f1607, previously 0x19f2f067b823cb5165699fe5616437ea4046b6d23feff5345e1261f0038f7603.
2023-06-14 12:16:18 ✨ Imported #49 (0x9419…1607)
2023-06-14 12:16:19 💤 Idle (0 peers), best: #49 (0x9419…1607), finalized #46 (0x9bcc…ca2b), ⬇ 0 ⬆ 0
2023-06-14 12:16:24 🙌 Starting consensus session on top of parent 0x9419828d463b8d142883524347f42594bfc636c4d86d4de66a0c2584bd5f1607
2023-06-14 12:16:24 added location Location { lat: 35.4808015958286162572, lon: 18.40484619140625 } to community with cid: sqm1v79dF6b
2023-06-14 12:16:24 added location Location { lat: 35.3576962044675155994, lon: 18.4062194824218714473 } to community with cid: sqm1v79dF6b
2023-06-14 12:16:24 added location Location { lat: 35.3599361628767567822, lon: 18.544921875 } to community with cid: sqm1v79dF6b
2023-06-14 12:16:24 added location Location { lat: 35.48751102385376299253, lon: 18.6808776855468714473 } to community with cid: sqm1v79dF6b
2023-06-14 12:16:24 added location Location { lat: 35.37001520672124144085, lon: 18.689117431640625 } to community with cid: sqm1v79dF6b
2023-06-14 12:16:24 added location Location { lat: 35.23215941201715395437, lon: 18.4075927734375 } to community with cid: sqm1v79dF6b
2023-06-14 12:16:24 added location Location { lat: 35.23888953232259524384, lon: 18.551788330078125 } to community with cid: sqm1v79dF6b
2023-06-14 12:16:24 added location Location { lat: 35.2489836657264490327, lon: 18.700103759765625 } to community with cid: sqm1v79dF6b
2023-06-14 12:16:24 🎁 Prepared block for proposing at 50 (1 ms) [hash: 0x524cfebe27557536502e071a694e6cbbbd2d5d334611e10f3394299ea774ae0a; parent_hash: 0x9419…1607; extrinsics (2): [0xa4c7…14f3, 0xc365…860c]]
2023-06-14 12:16:24 🔖 Pre-sealed block for proposal at 50. Hash now 0xd79d0ce07d6f74f966d501cdcc2d32e51ca02d9570aca3e90350863a81a081ac, previously 0x524cfebe27557536502e071a694e6cbbbd2d5d334611e10f3394299ea774ae0a.
2023-06-14 12:16:24 ✨ Imported #50 (0xd79d…81ac)
2023-06-14 12:16:24 Accepting new connection 1/100
2023-06-14 12:16:24 💤 Idle (0 peers), best: #50 (0xd79d…81ac), finalized #47 (0x37c9…1f8e), ⬇ 0 ⬆ 0
```

Bootstrap community with WsRpcClient:
```
2023-06-14 12:15:12 ✨ Imported #38 (0xa616…07ae)
2023-06-14 12:15:12 Accepting new connection 1/100
2023-06-14 12:15:12 Accepting new connection 1/100
2023-06-14 12:15:12 Accepting new connection 1/100
2023-06-14 12:15:12 Accepting new connection 1/100
2023-06-14 12:15:12 Accepting new connection 1/100
2023-06-14 12:15:14 💤 Idle (0 peers), best: #38 (0xa616…07ae), finalized #36 (0x23af…a55e), ⬇ 0 ⬆ 0
2023-06-14 12:15:18 🙌 Starting consensus session on top of parent 0xa61678e8a2b90b5eee4eab5fa78c48ed4ad0271db98782b54d6a3ec9073207ae
2023-06-14 12:15:18 added location Location { lat: 35.4808015958286162572, lon: 18.40484619140625 } to community with cid: sqm1v79dF6b
2023-06-14 12:15:18 added location Location { lat: 35.3576962044675155994, lon: 18.4062194824218714473 } to community with cid: sqm1v79dF6b
2023-06-14 12:15:18 added location Location { lat: 35.3599361628767567822, lon: 18.544921875 } to community with cid: sqm1v79dF6b
2023-06-14 12:15:18 added location Location { lat: 35.48751102385376299253, lon: 18.6808776855468714473 } to community with cid: sqm1v79dF6b
2023-06-14 12:15:18 added location Location { lat: 35.37001520672124144085, lon: 18.689117431640625 } to community with cid: sqm1v79dF6b
2023-06-14 12:15:18 added location Location { lat: 35.23215941201715395437, lon: 18.4075927734375 } to community with cid: sqm1v79dF6b
2023-06-14 12:15:18 added location Location { lat: 35.23888953232259524384, lon: 18.551788330078125 } to community with cid: sqm1v79dF6b
2023-06-14 12:15:18 added location Location { lat: 35.2489836657264490327, lon: 18.700103759765625 } to community with cid: sqm1v79dF6b
2023-06-14 12:15:18 🎁 Prepared block for proposing at 39 (1 ms) [hash: 0x6b2d38c81aa682f4bd70f12cce8435c4db43ddee555da418ec884943f19afbcf; parent_hash: 0xa616…07ae; extrinsics (2): [0xed15…cf15, 0xcd75…90e0]]
2023-06-14 12:15:18 🔖 Pre-sealed block for proposal at 39. Hash now 0x1e6c6c07e37f78f8486432a73bfb3a6ad13cb3c3fc04355bed4435cdeaea4a44, previously 0x6b2d38c81aa682f4bd70f12cce8435c4db43ddee555da418ec884943f19afbcf.
2023-06-14 12:15:18 ✨ Imported #39 (0x1e6c…4a44)
2023-06-14 12:15:18 Accepting new connection 1/100
2023-06-14 12:15:18 Accepting new connection 1/100
2023-06-14 12:15:18 Accepting new connection 1/100
2023-06-14 12:15:18 Accepting new connection 1/100
2023-06-14 12:15:19 💤 Idle (0 peers), best: #39 (0x1e6c…4a44), finalized #37 (0xe0b4…a44c), ⬇ 0 ⬆ 0

```
