### PR TITLE
bump pallets; bump versions: runtime v30, node/client v1.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,7 +2081,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-client-notee"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "clap 2.34.0",
  "clap-nested",
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-node-notee"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "clap 4.4.3",
  "encointer-balances-tx-payment-rpc",
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-node-notee-runtime"
-version = "1.5.29"
+version = "1.5.30"
 dependencies = [
  "encointer-balances-tx-payment",
  "encointer-balances-tx-payment-rpc-runtime-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2035,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-balances-tx-payment-rpc-runtime-api",
  "encointer-primitives",
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2072,7 +2072,7 @@ dependencies = [
 [[package]]
 name = "encointer-ceremonies-assignment"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -2116,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "encointer-meetup-validation"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -2244,7 +2244,7 @@ dependencies = [
 [[package]]
 name = "encointer-primitives"
 version = "1.3.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "bs58",
  "crc 2.1.0",
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "encointer-rpc"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "jsonrpsee",
  "thiserror",
@@ -2317,7 +2317,7 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 [[package]]
 name = "ep-core"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "array-bytes 6.1.0",
  "impl-serde 0.3.2",
@@ -5331,7 +5331,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-balances"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -5350,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -5367,7 +5367,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -5386,7 +5386,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -5397,7 +5397,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-meetup-validation",
@@ -5422,7 +5422,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -5441,7 +5441,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -5452,7 +5452,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities"
 version = "1.3.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -5471,7 +5471,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -5490,7 +5490,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "sp-api",
@@ -5500,7 +5500,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-democracy"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -5523,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-faucet"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -5544,7 +5544,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-reputation-commitments"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -5566,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-scheduler"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#e9e4646ea050097553b44868e604a64f6d815d1a"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v1.0.0-pallets-v1.3.0#7072b59b805690d154f195dc20073cfea5b2bd43"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -3,7 +3,7 @@ name = "encointer-client-notee"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2021"
 #keep with node version. major, minor and patch
-version = "1.5.3"
+version = "1.5.4"
 
 [dependencies]
 clap = "2.33"

--- a/client/src/community_spec.rs
+++ b/client/src/community_spec.rs
@@ -119,11 +119,11 @@ impl CommunitySpec for serde_json::Value {
 	fn demurrage(&self) -> Option<Demurrage> {
 		match serde_json::from_value::<u64>(self["community"]["demurrage_halving_blocks"].clone()) {
 			Ok(demurrage_halving_blocks) => {
-				let demurrage_rate = ln::<BalanceType, BalanceType>(BalanceType::from_num(0.5))
+				let demurrage_rate = ln::<Demurrage, Demurrage>(Demurrage::from_num(0.5))
 					.unwrap()
-					.checked_mul(BalanceType::from_num(-1))
+					.checked_mul(Demurrage::from_num(-1))
 					.unwrap()
-					.checked_div(BalanceType::from_num(demurrage_halving_blocks))
+					.checked_div(Demurrage::from_num(demurrage_halving_blocks))
 					.unwrap();
 
 				log::info!(

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -49,7 +49,7 @@ use encointer_node_notee_runtime::{
 	Signature, ONE_DAY,
 };
 use encointer_primitives::{
-	balances::Demurrage,
+	balances::{to_U64F64, Demurrage},
 	bazaar::{Business, BusinessIdentifier, OfferingData},
 	ceremonies::{
 		AttestationIndexType, ClaimOfAttendance, CommunityCeremony, CommunityReputation,
@@ -2509,18 +2509,18 @@ fn get_reputation(
 fn apply_demurrage(
 	entry: BalanceEntry<BlockNumber>,
 	current_block: BlockNumber,
-	demurrage_per_block: BalanceType,
+	demurrage_per_block: Demurrage,
 ) -> BalanceType {
 	let elapsed_time_block_number = current_block.checked_sub(entry.last_update).unwrap();
 	let elapsed_time_u32: u32 = elapsed_time_block_number;
-	let elapsed_time = BalanceType::from_num(elapsed_time_u32);
-	let exponent: BalanceType = -demurrage_per_block * elapsed_time;
+	let elapsed_time = Demurrage::from_num(elapsed_time_u32);
+	let exponent = -demurrage_per_block * elapsed_time;
 	debug!(
 		"demurrage per block {}, current_block {}, last {}, elapsed_blocks {}",
 		demurrage_per_block, current_block, entry.last_update, elapsed_time
 	);
-	let exp_result: BalanceType = exp(exponent).unwrap();
-	entry.principal.checked_mul(exp_result).unwrap()
+	let exp_result = exp(exponent).unwrap();
+	entry.principal.checked_mul(to_U64F64(exp_result).unwrap()).unwrap()
 }
 
 fn send_bazaar_xt(matches: &ArgMatches<'_>, bazaar_call: &BazaarCalls) -> Result<(), ()> {

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/encointer/encointer-node"
 #   * Align minor version with the runtime.
 #   * Bump patch version for new releases, and make it the release tag.
 #   * The client should follow this version.
-version = "1.5.3"
+version = "1.5.4"
 
 [[bin]]
 name = "encointer-node-notee"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,7 +7,7 @@ name = "encointer-node-notee-runtime"
 repository = "https://github.com/encointer/encointer-node/"
 # minor revision must match node/client
 # patch revision must match runtime spec_version
-version = "1.5.29"
+version = "1.5.30"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -419,7 +419,7 @@ parameter_types! {
 	pub const MomentsPerDay: Moment = 86_400_000; // [ms/d]
 	pub const DefaultDemurrage: Demurrage = Demurrage::from_bits(0x0000000000000000000001E3F0A8A973_i128);
 	/// 0.000005
-	pub const EncointerExistentialDeposit: BalanceType = BalanceType::from_bits(0x0000000000000000000053e2d6238da4_i128);
+	pub const EncointerExistentialDeposit: BalanceType = BalanceType::from_bits(0x0000000000000000000053e2d6238da4_u128);
 	pub const MeetupSizeTarget: u64 = 10;
 	pub const MeetupMinSize: u64 = 3;
 	pub const MeetupNewbieLimitDivider: u64 = 2;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -132,7 +132,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("encointer-node-notee"),
 	impl_name: create_runtime_str!("encointer-node-notee"),
 	authoring_version: 0,
-	spec_version: 29,
+	spec_version: 30,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 5,


### PR DESCRIPTION
Includes: https://github.com/encointer/pallets/pull/353