### PR TITLE
pimp cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,6 +2123,7 @@ dependencies = [
  "futures",
  "geojson",
  "hex",
+ "itertools 0.10.5",
  "log",
  "pallet-encointer-balances",
  "pallet-encointer-ceremonies",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-client-notee"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "clap 2.34.0",
  "clap-nested",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-node-notee"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "clap 4.5.1",
  "encointer-balances-tx-payment-rpc",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -3,7 +3,7 @@ name = "encointer-client-notee"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2021"
 #keep with node version. major, minor and patch
-version = "1.8.0"
+version = "1.8.1"
 
 [dependencies]
 # todo migrate to clap >=3 https://github.com/encointer/encointer-node/issues/107

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -37,6 +37,7 @@ substrate-client-keystore = { workspace = true }
 # substrate deps
 frame-support = { workspace = true, features = ["std"] }
 frame-system = { workspace = true, features = ["std"] }
+itertools = "0.10.5"
 pallet-transaction-payment = { workspace = true, features = ["std"] }
 sp-application-crypto = { workspace = true, features = ["std"] }
 sp-core = { workspace = true, features = ["std"] }
@@ -44,4 +45,3 @@ sp-keyring = { workspace = true }
 sp-keystore = { workspace = true, features = ["std"] }
 sp-rpc = { workspace = true }
 sp-runtime = { workspace = true, features = ["std"] }
-itertools = "0.10.5"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -44,3 +44,4 @@ sp-keyring = { workspace = true }
 sp-keystore = { workspace = true, features = ["std"] }
 sp-rpc = { workspace = true }
 sp-runtime = { workspace = true, features = ["std"] }
+itertools = "0.10.5"

--- a/client/encointer-api-client-extension/src/scheduler.rs
+++ b/client/encointer-api-client-extension/src/scheduler.rs
@@ -1,42 +1,51 @@
 use crate::{Api, Moment, Result};
+use encointer_node_notee_runtime::Hash;
 use encointer_primitives::scheduler::CeremonyPhaseType;
 use substrate_api_client::{api::error::Error as ApiClientError, GetStorage};
 
 #[maybe_async::maybe_async(?Send)]
 pub trait SchedulerApi {
-	async fn get_current_phase(&self) -> Result<CeremonyPhaseType>;
-	async fn get_next_phase_timestamp(&self) -> Result<Moment>;
-	async fn get_phase_duration(&self, phase: CeremonyPhaseType) -> Result<Moment>;
-	async fn get_start_of_attesting_phase(&self) -> Result<Moment>;
+	async fn get_current_phase(&self, maybe_at: Option<Hash>) -> Result<CeremonyPhaseType>;
+	async fn get_next_phase_timestamp(&self, maybe_at: Option<Hash>) -> Result<Moment>;
+	async fn get_phase_duration(
+		&self,
+		phase: CeremonyPhaseType,
+		maybe_at: Option<Hash>,
+	) -> Result<Moment>;
+	async fn get_start_of_attesting_phase(&self, maybe_at: Option<Hash>) -> Result<Moment>;
 }
 
 #[maybe_async::maybe_async(?Send)]
 impl SchedulerApi for Api {
-	async fn get_current_phase(&self) -> Result<CeremonyPhaseType> {
-		self.get_storage("EncointerScheduler", "CurrentPhase", None)
+	async fn get_current_phase(&self, maybe_at: Option<Hash>) -> Result<CeremonyPhaseType> {
+		self.get_storage("EncointerScheduler", "CurrentPhase", maybe_at)
 			.await?
 			.ok_or_else(|| ApiClientError::Other("Couldn't get CurrentPhase".into()))
 	}
 
-	async fn get_next_phase_timestamp(&self) -> Result<Moment> {
-		self.get_storage("EncointerScheduler", "NextPhaseTimestamp", None)
+	async fn get_next_phase_timestamp(&self, maybe_at: Option<Hash>) -> Result<Moment> {
+		self.get_storage("EncointerScheduler", "NextPhaseTimestamp", maybe_at)
 			.await?
 			.ok_or_else(|| ApiClientError::Other("Couldn't get NextPhaseTimestamp".into()))
 	}
 
-	async fn get_phase_duration(&self, phase: CeremonyPhaseType) -> Result<Moment> {
-		self.get_storage_map("EncointerScheduler", "PhaseDurations", phase, None)
+	async fn get_phase_duration(
+		&self,
+		phase: CeremonyPhaseType,
+		maybe_at: Option<Hash>,
+	) -> Result<Moment> {
+		self.get_storage_map("EncointerScheduler", "PhaseDurations", phase, maybe_at)
 			.await?
 			.ok_or_else(|| ApiClientError::Other("Couldn't get PhaseDuration".into()))
 	}
 
-	async fn get_start_of_attesting_phase(&self) -> Result<Moment> {
-		let next_phase_timestamp = self.get_next_phase_timestamp().await?;
+	async fn get_start_of_attesting_phase(&self, maybe_at: Option<Hash>) -> Result<Moment> {
+		let next_phase_timestamp = self.get_next_phase_timestamp(maybe_at).await?;
 
-		match self.get_current_phase().await? {
+		match self.get_current_phase(maybe_at).await? {
 			CeremonyPhaseType::Assigning => Ok(next_phase_timestamp), // - next_phase_timestamp.rem(ONE_DAY),
 			CeremonyPhaseType::Attesting => {
-				self.get_phase_duration(CeremonyPhaseType::Attesting)
+				self.get_phase_duration(CeremonyPhaseType::Attesting, maybe_at)
 					.await
 					.map(|dur| next_phase_timestamp - dur) //- next_phase_timestamp.rem(ONE_DAY)
 			},

--- a/client/py_client/client.py
+++ b/client/py_client/client.py
@@ -178,7 +178,7 @@ class Client:
                 participants = []
                 while len(lines) > 0:
                     l = lines.pop(0)
-                    if ('MeetupRegistry' in l) or ('total' in l):
+                    if ('MeetupRegistry' in l) or ('total' in l) or ('CSV' in l):
                         break
                     participants.append(l.strip())
                 meetups.append(participants)
@@ -257,37 +257,37 @@ class Client:
     def create_faucet(self, account, facuet_name, amount, drip_amount, whitelist, cid=None, pay_fees_in_cc=False):
         ret = self.run_cli_command(["create-faucet", account, facuet_name, str(amount), str(drip_amount)] + whitelist, cid, pay_fees_in_cc)
         return ret.stdout.decode("utf-8").strip()
-    
+
     def drip_faucet(self, account, facuet_account, cindex, cid=None, pay_fees_in_cc=False):
         ret = self.run_cli_command(["drip-faucet", account, facuet_account, str(cindex)], cid, pay_fees_in_cc)
         return ret.stdout.decode("utf-8").strip()
-    
+
     def dissolve_faucet(self, account, facuet_account, beneficiary, cid=None, pay_fees_in_cc=False):
         ret = self.run_cli_command(["dissolve-faucet", "--signer", account, facuet_account, beneficiary], cid, pay_fees_in_cc)
         return ret.stdout.decode("utf-8").strip()
-    
+
     def close_faucet(self, account, facuet_account, cid=None, pay_fees_in_cc=False):
         ret = self.run_cli_command(["close-faucet", account, facuet_account], cid, pay_fees_in_cc)
         return ret.stdout.decode("utf-8").strip()
-    
+
     def set_faucet_reserve_amount(self, account, amount, cid=None, pay_fees_in_cc=False):
         ret = self.run_cli_command(["set-faucet-reserve-amount", "--signer", account, str(amount)], cid, pay_fees_in_cc)
         return ret.stdout.decode("utf-8").strip()
-    
+
     def submit_set_inactivity_timeout_proposal(self, account, inactivity_timeout, cid=None, pay_fees_in_cc=False):
         ret = self.run_cli_command(["submit-set-inactivity-timeout-proposal", account, str(inactivity_timeout)], cid, pay_fees_in_cc)
         return ret.stdout.decode("utf-8").strip()
-    
+
     def vote(self, account, proposal_id, vote, reputations, cid=None, pay_fees_in_cc=False):
         reputations = [f'{cid}_{cindex}' for [cid,cindex] in reputations]
         reputation_vec = ','.join(reputations)
         ret = self.run_cli_command(["vote", account, str(proposal_id), vote, reputation_vec], cid, pay_fees_in_cc)
         return ret.stdout.decode("utf-8").strip()
-    
+
     def update_proposal_state(self, account, proposal_id, cid=None, pay_fees_in_cc=False):
         ret = self.run_cli_command(["update-proposal-state", account, str(proposal_id)], cid, pay_fees_in_cc)
         return ret.stdout.decode("utf-8").strip()
-    
+
     def list_proposals(self):
         ret = self.run_cli_command(["list-proposals"])
         return ret.stdout.decode("utf-8").strip()

--- a/client/py_client/client.py
+++ b/client/py_client/client.py
@@ -178,7 +178,7 @@ class Client:
                 participants = []
                 while len(lines) > 0:
                     l = lines.pop(0)
-                    if ('MeetupRegistry' in l) or ('total' in l) or ('CSV' in l):
+                    if ('MeetupRegistry' in l) or ('total' in l) or ('CSV:' in l):
                         break
                     participants.append(l.strip())
                 meetups.append(participants)

--- a/client/src/commands/encointer_ceremonies.rs
+++ b/client/src/commands/encointer_ceremonies.rs
@@ -47,11 +47,11 @@ pub fn list_participants(_args: &str, matches: &ArgMatches<'_>) -> Result<(), cl
 	let rt = tokio::runtime::Runtime::new().unwrap();
 	rt.block_on(async {
 		let api = get_chain_api(matches).await;
-		let at_block = matches.at_block_arg();
+		let maybe_at = matches.at_block_arg();
 		let cid =
-			verify_cid(&api, matches.cid_arg().expect("please supply argument --cid"), at_block)
+			verify_cid(&api, matches.cid_arg().expect("please supply argument --cid"), maybe_at)
 				.await;
-		let current_ceremony_index = get_ceremony_index(&api, at_block).await;
+		let current_ceremony_index = get_ceremony_index(&api, maybe_at).await;
 
 		let cindex = matches.ceremony_index_arg().map_or_else(
 			|| current_ceremony_index,
@@ -70,7 +70,7 @@ pub fn list_participants(_args: &str, matches: &ArgMatches<'_>) -> Result<(), cl
 			println!("Querying {}", registries[i]);
 
 			let count: ParticipantIndexType = api
-				.get_storage_map(ENCOINTER_CEREMONIES, counts[i], (cid, cindex), at_block)
+				.get_storage_map(ENCOINTER_CEREMONIES, counts[i], (cid, cindex), maybe_at)
 				.await
 				.unwrap()
 				.unwrap_or(0);
@@ -83,7 +83,7 @@ pub fn list_participants(_args: &str, matches: &ArgMatches<'_>) -> Result<(), cl
 						registries[i],
 						(cid, cindex),
 						p_index,
-						at_block,
+						maybe_at,
 					)
 					.await
 					.unwrap()
@@ -108,11 +108,11 @@ pub fn list_meetups(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::E
 	let rt = tokio::runtime::Runtime::new().unwrap();
 	rt.block_on(async {
 		let api = get_chain_api(matches).await;
-		let at_block = matches.at_block_arg();
+		let maybe_at = matches.at_block_arg();
 		let cid =
-			verify_cid(&api, matches.cid_arg().expect("please supply argument --cid"), at_block)
+			verify_cid(&api, matches.cid_arg().expect("please supply argument --cid"), maybe_at)
 				.await;
-		let current_ceremony_index = get_ceremony_index(&api, at_block).await;
+		let current_ceremony_index = get_ceremony_index(&api, maybe_at).await;
 
 		let cindex = matches.ceremony_index_arg().map_or_else(
 			|| current_ceremony_index,
@@ -123,7 +123,7 @@ pub fn list_meetups(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::E
 
 		println!("listing meetups for cid {cid} and ceremony nr {cindex}");
 
-		let stats = api.get_community_ceremony_stats(community_ceremony, at_block).await.unwrap();
+		let stats = api.get_community_ceremony_stats(community_ceremony, maybe_at).await.unwrap();
 
 		let mut num_assignees = 0u64;
 
@@ -163,11 +163,11 @@ pub fn print_ceremony_stats(_args: &str, matches: &ArgMatches<'_>) -> Result<(),
 	let rt = tokio::runtime::Runtime::new().unwrap();
 	rt.block_on(async {
 		let api = get_chain_api(matches).await;
-		let at_block = matches.at_block_arg();
+		let maybe_at = matches.at_block_arg();
 		let cid =
-			verify_cid(&api, matches.cid_arg().expect("please supply argument --cid"), at_block)
+			verify_cid(&api, matches.cid_arg().expect("please supply argument --cid"), maybe_at)
 				.await;
-		let current_ceremony_index = get_ceremony_index(&api, at_block).await;
+		let current_ceremony_index = get_ceremony_index(&api, maybe_at).await;
 
 		let cindex = matches.ceremony_index_arg().map_or_else(
 			|| current_ceremony_index,
@@ -176,7 +176,7 @@ pub fn print_ceremony_stats(_args: &str, matches: &ArgMatches<'_>) -> Result<(),
 
 		let community_ceremony = (cid, cindex);
 
-		let stats = api.get_community_ceremony_stats(community_ceremony, at_block).await.unwrap();
+		let stats = api.get_community_ceremony_stats(community_ceremony, maybe_at).await.unwrap();
 
 		// serialization prints the the account id better than `debug`
 		println!("{}", serde_json::to_string_pretty(&stats).unwrap());
@@ -188,12 +188,12 @@ pub fn list_attestees(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap:
 	let rt = tokio::runtime::Runtime::new().unwrap();
 	rt.block_on(async {
 		let api = get_chain_api(matches).await;
-		let at_block = matches.at_block_arg();
+		let maybe_at = matches.at_block_arg();
 		let cid =
-			verify_cid(&api, matches.cid_arg().expect("please supply argument --cid"), at_block)
+			verify_cid(&api, matches.cid_arg().expect("please supply argument --cid"), maybe_at)
 				.await;
 
-		let current_ceremony_index = get_ceremony_index(&api, at_block).await;
+		let current_ceremony_index = get_ceremony_index(&api, maybe_at).await;
 
 		let cindex = matches.ceremony_index_arg().map_or_else(
 			|| current_ceremony_index,
@@ -202,7 +202,7 @@ pub fn list_attestees(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap:
 
 		println!("listing attestees for cid {cid} and ceremony nr {cindex}");
 
-		let wcount = get_attestee_count(&api, (cid, cindex), at_block).await;
+		let wcount = get_attestee_count(&api, (cid, cindex), maybe_at).await;
 		println!("number of attestees:  {wcount}");
 
 		println!("listing participants for cid {cid} and ceremony nr {cindex}");
@@ -217,7 +217,7 @@ pub fn list_attestees(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap:
 						ENCOINTER_CEREMONIES,
 						counts_local[count_index],
 						(cid, cindex),
-						at_block,
+						maybe_at,
 					)
 					.await
 			}
@@ -235,7 +235,7 @@ pub fn list_attestees(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap:
 						registries_local[registry_index],
 						(cid, cindex),
 						p_index,
-						at_block,
+						maybe_at,
 					)
 					.await
 			}
@@ -252,7 +252,7 @@ pub fn list_attestees(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap:
 			for p_index in 1..count + 1 {
 				let accountid: AccountId = account_query(i, p_index).await.unwrap().unwrap();
 
-				match get_participant_attestation_index(&api, (cid, cindex), &accountid, at_block)
+				match get_participant_attestation_index(&api, (cid, cindex), &accountid, maybe_at)
 					.await
 				{
 					Some(windex) =>
@@ -267,13 +267,13 @@ pub fn list_attestees(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap:
 		for w in 1..wcount + 1 {
 			let attestor = participants_windex[&w].clone();
 			let meetup_index = api
-				.get_meetup_index(&(cid, cindex), &attestor, at_block)
+				.get_meetup_index(&(cid, cindex), &attestor, maybe_at)
 				.await
 				.unwrap()
 				.unwrap();
-			let attestees = api.get_attestees((cid, cindex), w, at_block).await.unwrap();
+			let attestees = api.get_attestees((cid, cindex), w, maybe_at).await.unwrap();
 			let vote = api
-				.get_meetup_participant_count_vote((cid, cindex), attestor.clone(), at_block)
+				.get_meetup_participant_count_vote((cid, cindex), attestor.clone(), maybe_at)
 				.await
 				.unwrap_or(0);
 			let attestation_state =
@@ -291,7 +291,7 @@ pub fn list_attestees(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap:
 
 		let mut meetup_sizes: HashMap<MeetupIndexType, usize> = HashMap::new();
 		let _: Vec<_> = api
-			.get_community_ceremony_stats((cid, cindex), at_block)
+			.get_community_ceremony_stats((cid, cindex), maybe_at)
 			.await
 			.unwrap()
 			.meetups
@@ -337,16 +337,16 @@ pub fn list_reputables(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap
         let api = get_chain_api(matches).await;
 
         let is_verbose = matches.verbose_flag();
-        let at_block = matches.at_block_arg();
+        let maybe_at = matches.at_block_arg();
 
-        let lifetime = get_reputation_lifetime(&api, at_block).await;
-        let current_ceremony_index = get_ceremony_index(&api, at_block).await;
+        let lifetime = get_reputation_lifetime(&api, maybe_at).await;
+        let current_ceremony_index = get_ceremony_index(&api, maybe_at).await;
 
 
         let first_ceremony_index_of_interest = current_ceremony_index.saturating_sub(lifetime);
         let ceremony_indices: Vec<u32> = (first_ceremony_index_of_interest..current_ceremony_index).collect();
 
-        let community_ids = get_community_identifiers(&api, at_block).await.expect("no communities found");
+        let community_ids = get_community_identifiers(&api, maybe_at).await.expect("no communities found");
 
         let mut reputables_csv = Vec::new();
 
@@ -355,7 +355,7 @@ pub fn list_reputables(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap
             println!("Community ID: {community_id:?}");
             let mut reputables: HashMap<AccountId, usize> = HashMap::new();
             for ceremony_index in &ceremony_indices {
-                let (attendees, noshows) = get_attendees_for_community_ceremony(&api, (community_id, *ceremony_index), at_block).await;
+                let (attendees, noshows) = get_attendees_for_community_ceremony(&api, (community_id, *ceremony_index), maybe_at).await;
                 println!("Cycle ID {ceremony_index:?}: Total attested attendees: {:} (noshows: {:})", attendees.len(), noshows.len());
                 for attendee in attendees {
                     reputables_csv.push(format!("{community_id:?},{ceremony_index:?},{}", attendee.to_ss58check()));
@@ -887,7 +887,7 @@ async fn get_reputation_history(
 async fn get_attendees_for_community_ceremony(
 	api: &Api,
 	community_ceremony: CommunityCeremony,
-	at_block: Option<Hash>,
+	maybe_at: Option<Hash>,
 ) -> (Vec<AccountId>, Vec<AccountId>) {
 	let key_prefix = api
 		.get_storage_double_map_key_prefix(
@@ -899,7 +899,7 @@ async fn get_attendees_for_community_ceremony(
 		.unwrap();
 	let max_keys = 1000;
 	let storage_keys = api
-		.get_storage_keys_paged(Some(key_prefix), max_keys, None, at_block)
+		.get_storage_keys_paged(Some(key_prefix), max_keys, None, maybe_at)
 		.await
 		.unwrap();
 
@@ -910,7 +910,7 @@ async fn get_attendees_for_community_ceremony(
 	let mut noshows = Vec::new();
 	for storage_key in storage_keys.iter() {
 		match api
-			.get_storage_by_key(storage_key.clone(), at_block)
+			.get_storage_by_key(storage_key.clone(), maybe_at)
 			.await
 			.unwrap_or(Some(Reputation::VerifiedLinked(0)))
 			.unwrap()
@@ -932,8 +932,8 @@ async fn get_attendees_for_community_ceremony(
 	(attendees, noshows)
 }
 
-async fn get_reputation_lifetime(api: &Api, at_block: Option<Hash>) -> ReputationLifetimeType {
-	api.get_storage("EncointerCeremonies", "ReputationLifetime", at_block)
+async fn get_reputation_lifetime(api: &Api, maybe_at: Option<Hash>) -> ReputationLifetimeType {
+	api.get_storage("EncointerCeremonies", "ReputationLifetime", maybe_at)
 		.await
 		.unwrap()
 		.unwrap_or(5)

--- a/client/src/commands/encointer_ceremonies.rs
+++ b/client/src/commands/encointer_ceremonies.rs
@@ -275,7 +275,7 @@ pub fn list_attestees(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap:
 			let vote = api
 				.get_meetup_participant_count_vote((cid, cindex), attestor.clone(), at_block)
 				.await
-				.unwrap();
+				.unwrap_or(0);
 			let attestation_state =
 				AttestationState::new((cid, cindex), meetup_index, vote, w, attestor, attestees);
 
@@ -307,7 +307,11 @@ pub fn list_attestees(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap:
 					votes.push(a.vote);
 				}
 			}
-			let mean_vote: f64 = votes.iter().sum::<u32>() as f64 / votes.len() as f64;
+			let mut mean_vote: f64 = votes.iter().sum::<u32>() as f64 / votes.len() as f64;
+			if mean_vote.is_nan() {
+				mean_vote = 0f64;
+			}
+
 			all_votes.insert(*m, mean_vote);
 			println!(
 				"CSVmeetupVotes: {cindex}, {cid}, {m}, {}, {:.3}, {:?}",
@@ -317,7 +321,12 @@ pub fn list_attestees(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap:
 			);
 		}
 
-		println!("CSV: {cindex}, {cid}, {wcount}, {}", all_votes.values().sum::<f64>());
+		println!("cindex, cid, assignees, attestors, sum of mean votes");
+		println!(
+			"CSV: {cindex}, {cid}, {}, {wcount}, {}",
+			meetup_sizes.values().sum::<usize>(),
+			all_votes.values().sum::<f64>()
+		);
 		Ok(())
 	})
 	.into()

--- a/client/src/commands/encointer_ceremonies.rs
+++ b/client/src/commands/encointer_ceremonies.rs
@@ -912,6 +912,7 @@ async fn get_attendees_for_community_ceremony(
 		match api
 			.get_storage_by_key(storage_key.clone(), maybe_at)
 			.await
+			// todo: back to simple unwarp()  https://github.com/encointer/encointer-node/issues/364
 			.unwrap_or(Some(Reputation::VerifiedLinked(0)))
 			.unwrap()
 		{

--- a/client/src/commands/encointer_communities.rs
+++ b/client/src/commands/encointer_communities.rs
@@ -81,7 +81,7 @@ pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
         send_and_wait_for_in_block(&api, xt(&api, new_community_call).await, matches.tx_payment_cid_arg()).await;
         println!("{cid}");
 
-        if api.get_current_phase().await.unwrap() != CeremonyPhaseType::Registering {
+        if api.get_current_phase(None).await.unwrap() != CeremonyPhaseType::Registering {
             error!("Wrong ceremony phase for registering new locations for {}", cid);
             error!("Aborting without registering additional locations");
             std::process::exit(exit_code::WRONG_PHASE);
@@ -144,7 +144,7 @@ pub fn add_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
             println!("0x{}", hex::encode(add_location_maybe_batch_call.encode()));
         } else {
             // ---- send xt's to chain
-            if api.get_current_phase().await.unwrap() != CeremonyPhaseType::Registering {
+            if api.get_current_phase(None).await.unwrap() != CeremonyPhaseType::Registering {
                 error!("Wrong ceremony phase for registering new locations for {}", cid);
                 error!("Aborting without registering additional locations");
                 std::process::exit(exit_code::WRONG_PHASE);

--- a/client/src/commands/encointer_core.rs
+++ b/client/src/commands/encointer_core.rs
@@ -235,10 +235,10 @@ pub async fn get_community_issuance(
 async fn get_demurrage_per_block(
 	api: &Api,
 	cid: CommunityIdentifier,
-	at_block: Option<Hash>,
+	maybe_at: Option<Hash>,
 ) -> Demurrage {
 	let d: Option<Demurrage> = api
-		.get_storage_map("EncointerBalances", "DemurragePerBlock", cid, at_block)
+		.get_storage_map("EncointerBalances", "DemurragePerBlock", cid, maybe_at)
 		.await
 		.unwrap();
 

--- a/client/src/commands/encointer_democracy.rs
+++ b/client/src/commands/encointer_democracy.rs
@@ -48,12 +48,12 @@ pub fn list_proposals(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap:
 	let rt = tokio::runtime::Runtime::new().unwrap();
 	rt.block_on(async {
 		let api = get_chain_api(matches).await;
-		let at_block = matches.at_block_arg();
+		let maybe_at = matches.at_block_arg();
 		let key_prefix =
 			api.get_storage_map_key_prefix("EncointerDemocracy", "Proposals").await.unwrap();
 		let max_keys = 1000;
 		let storage_keys = api
-			.get_storage_keys_paged(Some(key_prefix), max_keys, None, at_block)
+			.get_storage_keys_paged(Some(key_prefix), max_keys, None, maybe_at)
 			.await
 			.unwrap();
 		if storage_keys.len() == max_keys as usize {
@@ -66,7 +66,7 @@ pub fn list_proposals(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap:
 					.unwrap();
 			println!("id: {}", proposal_id);
 			let proposal: Proposal<Moment> =
-				api.get_storage_by_key(storage_key.clone(), at_block).await.unwrap().unwrap();
+				api.get_storage_by_key(storage_key.clone(), maybe_at).await.unwrap().unwrap();
 			println!("action: {:?}", proposal.action);
 			println!("start block: {}", proposal.start);
 			println!("start cindex: {}", proposal.start_cindex);

--- a/client/src/commands/encointer_faucet.rs
+++ b/client/src/commands/encointer_faucet.rs
@@ -257,14 +257,14 @@ pub fn list_faucets(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::E
 		let api = get_chain_api(matches).await;
 
 		let is_verbose = matches.verbose_flag();
-		let at_block = matches.at_block_arg();
+		let maybe_at = matches.at_block_arg();
 
 		let key_prefix =
 			api.get_storage_map_key_prefix("EncointerFaucet", "Faucets").await.unwrap();
 
 		let max_keys = 1000;
 		let storage_keys = api
-			.get_storage_keys_paged(Some(key_prefix), max_keys, None, at_block)
+			.get_storage_keys_paged(Some(key_prefix), max_keys, None, maybe_at)
 			.await
 			.unwrap();
 
@@ -277,7 +277,7 @@ pub fn list_faucets(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::E
 			let faucet_address =
 				AccountId::decode(&mut key_postfix[key_postfix.len() - 32..].as_ref()).unwrap();
 			let faucet: Faucet<AccountId, Balance> =
-				api.get_storage_by_key(storage_key.clone(), at_block).await.unwrap().unwrap();
+				api.get_storage_by_key(storage_key.clone(), maybe_at).await.unwrap().unwrap();
 
 			if is_verbose {
 				println!("address: {}", faucet_address.to_ss58check());

--- a/client/src/commands/encointer_scheduler.rs
+++ b/client/src/commands/encointer_scheduler.rs
@@ -79,8 +79,8 @@ pub fn next_phase(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Err
 	.into()
 }
 
-pub async fn get_ceremony_index(api: &Api, at_block: Option<Hash>) -> CeremonyIndexType {
-	api.get_storage("EncointerScheduler", "CurrentCeremonyIndex", at_block)
+pub async fn get_ceremony_index(api: &Api, maybe_at: Option<Hash>) -> CeremonyIndexType {
+	api.get_storage("EncointerScheduler", "CurrentCeremonyIndex", maybe_at)
 		.await
 		.unwrap()
 		.unwrap()

--- a/client/src/commands/encointer_scheduler.rs
+++ b/client/src/commands/encointer_scheduler.rs
@@ -26,11 +26,11 @@ pub fn get_phase(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Erro
 		debug!("block number: {}", bn);
 		let cindex = get_ceremony_index(&api, None).await;
 		info!("ceremony index: {}", cindex);
-		let tnext: Moment = api.get_next_phase_timestamp().await.unwrap();
+		let tnext: Moment = api.get_next_phase_timestamp(None).await.unwrap();
 		debug!("next phase timestamp: {}", tnext);
 		// <<<<
 
-		let phase = api.get_current_phase().await.unwrap();
+		let phase = api.get_current_phase(None).await.unwrap();
 		println!("{phase:?}");
 		Ok(())
 	})
@@ -72,7 +72,7 @@ pub fn next_phase(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Err
 
 		send_and_wait_for_in_block(&api, xt(&api, next_phase_call).await, tx_payment_cid_arg).await;
 
-		let phase = api.get_current_phase().await.unwrap();
+		let phase = api.get_current_phase(None).await.unwrap();
 		println!("Phase is now: {phase:?}");
 		Ok(())
 	})

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -265,7 +265,7 @@ fn main() {
 		    Command::new("list-participants")
 		        .description("list all registered participants supplied community identifier and ceremony index")
 		        .options(|app| {
-		        app.setting(AppSettings::ColoredHelp)
+		        app.setting(AppSettings::ColoredHelp).setting(AppSettings::AllowNegativeNumbers)
 		            .ceremony_index_arg()
 					.at_block_arg()
 		        })
@@ -275,7 +275,7 @@ fn main() {
 		    Command::new("list-meetups")
 		        .description("list all assigned meetups for supplied community identifier and ceremony index")
 		        .options(|app| {
-		            app.setting(AppSettings::ColoredHelp)
+		            app.setting(AppSettings::ColoredHelp).setting(AppSettings::AllowNegativeNumbers)
 		                .ceremony_index_arg()
 						.at_block_arg()
 		        })
@@ -285,7 +285,7 @@ fn main() {
 		    Command::new("print-ceremony-stats")
 		        .description("pretty prints all information for a community ceremony")
 		        .options(|app| {
-		            app.setting(AppSettings::ColoredHelp)
+		            app.setting(AppSettings::ColoredHelp).setting(AppSettings::AllowNegativeNumbers)
 		                .ceremony_index_arg()
 						.at_block_arg()
 		        })
@@ -295,7 +295,7 @@ fn main() {
 		    Command::new("list-attestees")
 		        .description("list all attestees for participants for supplied community identifier and ceremony index")
 		        .options(|app| {
-		            app.setting(AppSettings::ColoredHelp)
+		            app.setting(AppSettings::ColoredHelp).setting(AppSettings::AllowNegativeNumbers)
 		                .ceremony_index_arg()
 						.at_block_arg()
 		        })
@@ -335,7 +335,7 @@ fn main() {
 		    Command::new("unregister-participant")
 		        .description("Unregister encointer ceremony participant for supplied community")
 		        .options(|app| {
-		            app.setting(AppSettings::ColoredHelp)
+		            app.setting(AppSettings::ColoredHelp).setting(AppSettings::AllowNegativeNumbers)
 		            .account_arg()
 		            .signer_arg("Account which signs the tx.")
 		            .ceremony_index_arg()
@@ -365,7 +365,7 @@ fn main() {
 		        .description("creates a proof of ProofOfAttendances for an <account> for the given ceremony index")
 		        .options(|app| {
 		            app.setting(AppSettings::ColoredHelp)
-		                .setting(AppSettings::AllowLeadingHyphen)
+		                .setting(AppSettings::AllowNegativeNumbers)
 		                .account_arg()
 		                .ceremony_index_arg()
 		        })

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -232,6 +232,10 @@ fn main() {
 		.add_cmd(
 		    Command::new("list-communities")
 		        .description("list all registered communities")
+				.options(|app| {
+		            app.setting(AppSettings::ColoredHelp)
+		                .at_block_arg()
+		        })
 		        .runner(commands::encointer_communities::list_communities),
 		)
 		.add_cmd(
@@ -263,6 +267,7 @@ fn main() {
 		        .options(|app| {
 		        app.setting(AppSettings::ColoredHelp)
 		            .ceremony_index_arg()
+					.at_block_arg()
 		        })
 		        .runner(commands::encointer_ceremonies::list_participants),
 		)
@@ -272,6 +277,7 @@ fn main() {
 		        .options(|app| {
 		            app.setting(AppSettings::ColoredHelp)
 		                .ceremony_index_arg()
+						.at_block_arg()
 		        })
 		        .runner(commands::encointer_ceremonies::list_meetups),
 		)
@@ -281,6 +287,7 @@ fn main() {
 		        .options(|app| {
 		            app.setting(AppSettings::ColoredHelp)
 		                .ceremony_index_arg()
+						.at_block_arg()
 		        })
 		        .runner(commands::encointer_ceremonies::print_ceremony_stats),
 		)
@@ -290,6 +297,7 @@ fn main() {
 		        .options(|app| {
 		            app.setting(AppSettings::ColoredHelp)
 		                .ceremony_index_arg()
+						.at_block_arg()
 		        })
 		        .runner(commands::encointer_ceremonies::list_attestees),
 		)

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/encointer/encointer-node"
 #   * Align major and minor version with polkadot-sdk major.minor.
 #   * Bump patch version for new releases, and make it the release tag.
 #   * The client should follow this version.
-version = "1.8.0"
+version = "1.8.1"
 
 [[bin]]
 name = "encointer-node-notee"


### PR DESCRIPTION
closes #282

* make client work with pre-migration `Reputation` type
* make use of `--at` argument for all queries which can work without custom rpc (where block can't be specified)
* make stout parsable as CSV for `list-participants, list-meetups, list-attestees`