### PR TITLE
more gathering locations for nyota

### DIFF
--- a/client/test-data/nyota.locations.json
+++ b/client/test-data/nyota.locations.json
@@ -1,0 +1,60 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          39.24361541135886,
+          -6.813869765106247
+        ],
+        "type": "Point"
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          39.24437727567272,
+          -6.813849502164388
+        ],
+        "type": "Point"
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          39.24378547035721,
+          -6.8143898469736115
+        ],
+        "type": "Point"
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          39.24281953524391,
+          -6.814396601279668
+        ],
+        "type": "Point"
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          39.2415679010131,
+          -6.813856256478061
+        ],
+        "type": "Point"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This adds the geojson spec for 5 additional gathering locations in close vicinity

command to get council propose extrinsic:

```
nctr-k add-locations --dryrun test-data/nyota.locations.json --cid kygch5kVGq7
0x3202102800143e016b79676368b9d2149200005caa273ba62ff9ffffffffffffff0000809660945d3e27000000000000003e016b79676368b9d2149200008c561c8fa72ff9ffffffffffffff000060e656828f3e27000000000000003e016b79676368b9d214920000cc0da125842ff9ffffffffffffff0000986c7eb9683e27000000000000003e016b79676368b9d214920000c0874fb4832ff9ffffffffffffff0000d8b3ca6b293e27000000000000003e016b79676368b9d21492000020c8ca1da72ff9ffffffffffffff0000589dda64d73d27000000000000007903

```