### PR TITLE
Add more commands to the encointer-client docker image and test them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,277 +26,277 @@ jobs:
       - uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
-  build:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install protoc
-        run: sudo apt-get install protobuf-compiler
-
-        # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-        # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
-      - name: Setup Rust toolchain
-        run: rustup show
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "release"
-
-      - name: Build
-        run: cargo build --release
-      - name: Upload node
-        uses: actions/upload-artifact@v4
-        with:
-          name: encointer-node-notee-${{ github.sha }}
-          path: target/release/encointer-node-notee
-      - name: Upload CLI client
-        uses: actions/upload-artifact@v4
-        with:
-          name: encointer-client-notee-${{ github.sha }}
-          path: target/release/encointer-client-notee
-
-  build-try-runtime-and-benchmarks:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install protoc
-        run: sudo apt-get install protobuf-compiler
-
-        # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-        # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
-      - name: Setup Rust toolchain
-        run: rustup show
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "release"
-
-      - name: Build
-        run: cargo build --release --features try-runtime,runtime-benchmarks
-      - name: Upload node
-        uses: actions/upload-artifact@v4
-        with:
-          name: encointer-node-notee-try-runtime-and-benchmarks-${{ github.sha }}
-          path: target/release/encointer-node-notee
-      - name: Upload CLI client
-        uses: actions/upload-artifact@v4
-        with:
-          name: encointer-client-notee-try-runtime-and-benchmarks-${{ github.sha }}
-          path: target/release/encointer-client-notee
-
-  build-runtimes:
-    name: Build Runtimes
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        runtime: [ "encointer-node-notee" ]
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Cache target dir
-        uses: actions/cache@v3
-        with:
-          path: "${{ github.workspace }}/runtime/target"
-          key: srtool-target-${{ matrix.runtime }}-${{ github.sha }}
-          restore-keys: |
-            srtool-target-${{ matrix.runtime }}-
-            srtool-target-
-
-      - name: Srtool build
-        id: srtool_build
-        uses: chevdor/srtool-actions@v0.9.2
-        with:
-          image: paritytech/srtool
-          tag: 1.77.0
-          chain: ${{ matrix.runtime }}
-          runtime_dir: runtime
-
-      - name: Summary
-        run: |
-          echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.runtime }}-srtool-digest.json
-          cat ${{ matrix.runtime }}-srtool-digest.json
-          echo "Compact Runtime: ${{ steps.srtool_build.outputs.wasm }}"
-          echo "Compressed Runtime: ${{ steps.srtool_build.outputs.wasm_compressed }}"
-      # We now get extra information thanks to subwasm
-      - name: Install subwasm
-        run: |
-          wget https://github.com/chevdor/subwasm/releases/download/v${{ env.SUBWASM_VERSION }}/subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
-          sudo dpkg -i subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
-          subwasm --version
-      - name: Show Runtime information
-        shell: bash
-        run: |
-          subwasm info ${{ steps.srtool_build.outputs.wasm }}
-          subwasm info ${{ steps.srtool_build.outputs.wasm_compressed }}
-          subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.runtime }}-info.json
-          subwasm --json info ${{ steps.srtool_build.outputs.wasm_compressed }} > ${{ matrix.runtime }}-compressed-info.json
-      - name: Extract the metadata
-        shell: bash
-        run: |
-          subwasm meta ${{ steps.srtool_build.outputs.wasm }}
-          subwasm --json meta ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.runtime }}-metadata.json
-      # This is unsupported it wants to diff the metadata with a running chain. i.e. wss://kusama-<matrix.chain>-rpc.parity.io
-      #      - name: Check the metadata diff
-      #        shell: bash
-      #        run: |
-      #          subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.chain }} > ${{ matrix.chain }}-diff.txt
-      #          cat ${{ matrix.chain }}-diff.txt
-
-      - name: Upload ${{ matrix.runtime }} srtool json
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.runtime }}-srtool-json-${{ github.sha }}
-          path: |
-            ${{ matrix.runtime }}-srtool-digest.json
-            ${{ matrix.runtime }}-info.json
-            ${{ matrix.runtime }}-compressed-info.json
-            ${{ matrix.runtime }}-metadata.json
-      #            ${{ matrix.runtime }}-diff.txt
-
-
-      - name: Upload ${{ matrix.runtime }} runtime
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.runtime }}-runtime-${{ github.sha }}
-          path: |
-            ${{ steps.srtool_build.outputs.wasm }}
-            ${{ steps.srtool_build.outputs.wasm_compressed }}
-
-  unit-tests:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install protoc
-        run: sudo apt-get install protobuf-compiler
-
-        # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-        # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
-      - name: Setup Rust toolchain
-        run: rustup show
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "debug"
-
-      - name: cargo test
-        run: cargo test --all
-
-  check:
-    name: Rust check ${{ matrix.check }} (${{ matrix.rust-target }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-22.04 ]
-        rust: [ stable ]
-        rust-target: [ x86_64-unknown-linux-gnu ]
-        check: [ +nightly fmt --all -- --check, clippy -p encointer-client-notee ]
-    env:
-      RUST_BACKTRACE: full
-      RUSTV: ${{ matrix.rust }}
-      TARGET: ${{ matrix.rust-target }}
-    steps:
-      - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          components: rustfmt
-
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install protoc
-        run: sudo apt-get install protobuf-compiler
-
-      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
-      - name: Setup Rust toolchain
-        run: rustup show
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "debug"
-
-      - name: ${{ matrix.check }}
-        run: cargo ${{ matrix.check }}
-
-  cargo-toml-fmt:
-    runs-on: ubuntu-22.04
-    container: "tamasfe/taplo:0.7.0-alpine"
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Run Taplo fmt
-        run: taplo fmt --check
-
-      - name: Fail-fast; cancel other jobs
-        if: failure()
-        uses: andymckay/cancel-action@0.3
-
-  integration-test:
-    name: ${{ matrix.test }}
-    runs-on: ubuntu-22.04
-    needs: build
-    strategy:
-      matrix:
-        test: [ test_bootstrap_demo_community.sh, test_bot_community.sh, test_register_business.sh ]
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: encointer-node-notee-${{ github.sha }}
-
-      - name: download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: encointer-client-notee-${{ github.sha }}
-
-      - name: fix permissions of artifacts and move to original folder
-        run: |
-          chmod +x encointer-node-notee
-          chmod +x encointer-client-notee
-          mkdir -p target/release
-          mv encointer-*-notee target/release
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
-      - name: install py dependencies
-        run: ./scripts/install_python_deps.sh
-
-      - name: Set up ipfs
-        uses: ibnesayeed/setup-ipfs@master
-        with:
-          run_daemon: true
-
-      - name: start dev node
-        run:
-          ./target/release/encointer-node-notee --tmp --dev --enable-offchain-indexing true --rpc-methods unsafe &
-
-      - name: start faucet service
-        run: |
-          cd client
-          python faucet.py &
-
-      - name: start phase accelerator service
-        run: |
-          cd client
-          python phase.py --idle-blocks 3 &
-
-      - name: Test ${{ matrix.test }}
-        working-directory: ./scripts/ci
-        run: source ./init_env.sh && ./${{ matrix.test }}
+  #  build:
+  #    runs-on: ubuntu-22.04
+  #    steps:
+  #      - uses: actions/checkout@v3
+  #
+  #      - name: Install protoc
+  #        run: sudo apt-get install protobuf-compiler
+  #
+  #        # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
+  #        # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
+  #      - name: Setup Rust toolchain
+  #        run: rustup show
+  #
+  #      - uses: Swatinem/rust-cache@v2
+  #        with:
+  #          shared-key: "release"
+  #
+  #      - name: Build
+  #        run: cargo build --release
+  #      - name: Upload node
+  #        uses: actions/upload-artifact@v4
+  #        with:
+  #          name: encointer-node-notee-${{ github.sha }}
+  #          path: target/release/encointer-node-notee
+  #      - name: Upload CLI client
+  #        uses: actions/upload-artifact@v4
+  #        with:
+  #          name: encointer-client-notee-${{ github.sha }}
+  #          path: target/release/encointer-client-notee
+  #
+  #  build-try-runtime-and-benchmarks:
+  #    runs-on: ubuntu-22.04
+  #    steps:
+  #      - uses: actions/checkout@v3
+  #
+  #      - name: Install protoc
+  #        run: sudo apt-get install protobuf-compiler
+  #
+  #        # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
+  #        # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
+  #      - name: Setup Rust toolchain
+  #        run: rustup show
+  #
+  #      - uses: Swatinem/rust-cache@v2
+  #        with:
+  #          shared-key: "release"
+  #
+  #      - name: Build
+  #        run: cargo build --release --features try-runtime,runtime-benchmarks
+  #      - name: Upload node
+  #        uses: actions/upload-artifact@v4
+  #        with:
+  #          name: encointer-node-notee-try-runtime-and-benchmarks-${{ github.sha }}
+  #          path: target/release/encointer-node-notee
+  #      - name: Upload CLI client
+  #        uses: actions/upload-artifact@v4
+  #        with:
+  #          name: encointer-client-notee-try-runtime-and-benchmarks-${{ github.sha }}
+  #          path: target/release/encointer-client-notee
+  #
+  #  build-runtimes:
+  #    name: Build Runtimes
+  #    runs-on: ubuntu-22.04
+  #    strategy:
+  #      matrix:
+  #        runtime: [ "encointer-node-notee" ]
+  #    steps:
+  #      - uses: actions/checkout@v3
+  #
+  #      - name: Cache target dir
+  #        uses: actions/cache@v3
+  #        with:
+  #          path: "${{ github.workspace }}/runtime/target"
+  #          key: srtool-target-${{ matrix.runtime }}-${{ github.sha }}
+  #          restore-keys: |
+  #            srtool-target-${{ matrix.runtime }}-
+  #            srtool-target-
+  #
+  #      - name: Srtool build
+  #        id: srtool_build
+  #        uses: chevdor/srtool-actions@v0.9.2
+  #        with:
+  #          image: paritytech/srtool
+  #          tag: 1.77.0
+  #          chain: ${{ matrix.runtime }}
+  #          runtime_dir: runtime
+  #
+  #      - name: Summary
+  #        run: |
+  #          echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.runtime }}-srtool-digest.json
+  #          cat ${{ matrix.runtime }}-srtool-digest.json
+  #          echo "Compact Runtime: ${{ steps.srtool_build.outputs.wasm }}"
+  #          echo "Compressed Runtime: ${{ steps.srtool_build.outputs.wasm_compressed }}"
+  #      # We now get extra information thanks to subwasm
+  #      - name: Install subwasm
+  #        run: |
+  #          wget https://github.com/chevdor/subwasm/releases/download/v${{ env.SUBWASM_VERSION }}/subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+  #          sudo dpkg -i subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+  #          subwasm --version
+  #      - name: Show Runtime information
+  #        shell: bash
+  #        run: |
+  #          subwasm info ${{ steps.srtool_build.outputs.wasm }}
+  #          subwasm info ${{ steps.srtool_build.outputs.wasm_compressed }}
+  #          subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.runtime }}-info.json
+  #          subwasm --json info ${{ steps.srtool_build.outputs.wasm_compressed }} > ${{ matrix.runtime }}-compressed-info.json
+  #      - name: Extract the metadata
+  #        shell: bash
+  #        run: |
+  #          subwasm meta ${{ steps.srtool_build.outputs.wasm }}
+  #          subwasm --json meta ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.runtime }}-metadata.json
+  #      # This is unsupported it wants to diff the metadata with a running chain. i.e. wss://kusama-<matrix.chain>-rpc.parity.io
+  #      #      - name: Check the metadata diff
+  #      #        shell: bash
+  #      #        run: |
+  #      #          subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.chain }} > ${{ matrix.chain }}-diff.txt
+  #      #          cat ${{ matrix.chain }}-diff.txt
+  #
+  #      - name: Upload ${{ matrix.runtime }} srtool json
+  #        uses: actions/upload-artifact@v4
+  #        with:
+  #          name: ${{ matrix.runtime }}-srtool-json-${{ github.sha }}
+  #          path: |
+  #            ${{ matrix.runtime }}-srtool-digest.json
+  #            ${{ matrix.runtime }}-info.json
+  #            ${{ matrix.runtime }}-compressed-info.json
+  #            ${{ matrix.runtime }}-metadata.json
+  #      #            ${{ matrix.runtime }}-diff.txt
+  #
+  #
+  #      - name: Upload ${{ matrix.runtime }} runtime
+  #        uses: actions/upload-artifact@v4
+  #        with:
+  #          name: ${{ matrix.runtime }}-runtime-${{ github.sha }}
+  #          path: |
+  #            ${{ steps.srtool_build.outputs.wasm }}
+  #            ${{ steps.srtool_build.outputs.wasm_compressed }}
+  #
+  #  unit-tests:
+  #    runs-on: ubuntu-22.04
+  #    steps:
+  #      - uses: actions/checkout@v3
+  #
+  #      - name: Install protoc
+  #        run: sudo apt-get install protobuf-compiler
+  #
+  #        # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
+  #        # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
+  #      - name: Setup Rust toolchain
+  #        run: rustup show
+  #
+  #      - uses: Swatinem/rust-cache@v2
+  #        with:
+  #          shared-key: "debug"
+  #
+  #      - name: cargo test
+  #        run: cargo test --all
+  #
+  #  check:
+  #    name: Rust check ${{ matrix.check }} (${{ matrix.rust-target }})
+  #    runs-on: ${{ matrix.os }}
+  #    strategy:
+  #      matrix:
+  #        os: [ ubuntu-22.04 ]
+  #        rust: [ stable ]
+  #        rust-target: [ x86_64-unknown-linux-gnu ]
+  #        check: [ +nightly fmt --all -- --check, clippy -p encointer-client-notee ]
+  #    env:
+  #      RUST_BACKTRACE: full
+  #      RUSTV: ${{ matrix.rust }}
+  #      TARGET: ${{ matrix.rust-target }}
+  #    steps:
+  #      - name: Install nightly toolchain
+  #        uses: actions-rs/toolchain@v1
+  #        with:
+  #          profile: minimal
+  #          toolchain: nightly
+  #          components: rustfmt
+  #
+  #      - name: Checkout
+  #        uses: actions/checkout@v3
+  #
+  #      - name: Install protoc
+  #        run: sudo apt-get install protobuf-compiler
+  #
+  #      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
+  #      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
+  #      - name: Setup Rust toolchain
+  #        run: rustup show
+  #
+  #      - uses: Swatinem/rust-cache@v2
+  #        with:
+  #          shared-key: "debug"
+  #
+  #      - name: ${{ matrix.check }}
+  #        run: cargo ${{ matrix.check }}
+  #
+  #  cargo-toml-fmt:
+  #    runs-on: ubuntu-22.04
+  #    container: "tamasfe/taplo:0.7.0-alpine"
+  #    steps:
+  #      - uses: actions/checkout@v3
+  #
+  #      - name: Run Taplo fmt
+  #        run: taplo fmt --check
+  #
+  #      - name: Fail-fast; cancel other jobs
+  #        if: failure()
+  #        uses: andymckay/cancel-action@0.3
+  #
+  #  integration-test:
+  #    name: ${{ matrix.test }}
+  #    runs-on: ubuntu-22.04
+  #    needs: build
+  #    strategy:
+  #      matrix:
+  #        test: [ test_bootstrap_demo_community.sh, test_bot_community.sh, test_register_business.sh ]
+  #    steps:
+  #      - uses: actions/checkout@v3
+  #
+  #      - name: download build artifacts
+  #        uses: actions/download-artifact@v4
+  #        with:
+  #          name: encointer-node-notee-${{ github.sha }}
+  #
+  #      - name: download build artifacts
+  #        uses: actions/download-artifact@v4
+  #        with:
+  #          name: encointer-client-notee-${{ github.sha }}
+  #
+  #      - name: fix permissions of artifacts and move to original folder
+  #        run: |
+  #          chmod +x encointer-node-notee
+  #          chmod +x encointer-client-notee
+  #          mkdir -p target/release
+  #          mv encointer-*-notee target/release
+  #
+  #      - name: Set up Python
+  #        uses: actions/setup-python@v4
+  #        with:
+  #          python-version: 3.7
+  #      - name: install py dependencies
+  #        run: ./scripts/install_python_deps.sh
+  #
+  #      - name: Set up ipfs
+  #        uses: ibnesayeed/setup-ipfs@master
+  #        with:
+  #          run_daemon: true
+  #
+  #      - name: start dev node
+  #        run:
+  #          ./target/release/encointer-node-notee --tmp --dev --enable-offchain-indexing true --rpc-methods unsafe &
+  #
+  #      - name: start faucet service
+  #        run: |
+  #          cd client
+  #          python faucet.py &
+  #
+  #      - name: start phase accelerator service
+  #        run: |
+  #          cd client
+  #          python phase.py --idle-blocks 3 &
+  #
+  #      - name: Test ${{ matrix.test }}
+  #        working-directory: ./scripts/ci
+  #        run: source ./init_env.sh && ./${{ matrix.test }}
 
   integration-test-docker:
     name: ${{ matrix.test }}
     runs-on: ubuntu-22.04
-    needs: build
+    #    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -402,91 +402,91 @@ jobs:
             -r ws://host.docker.internal \
             --port 9944 \
 
-  release:
-    name: Draft Release
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-22.04
-    needs: [ build, unit-tests, check, integration-test ]
-    outputs:
-      release_url: ${{ steps.create-release.outputs.html_url }}
-      asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Download Encointer Node
-        uses: actions/download-artifact@v4
-        with:
-          name: encointer-node-notee-${{ github.sha }}
-
-      - name: Download Encointer Client
-        uses: actions/download-artifact@v4
-        with:
-          name: encointer-client-notee-${{ github.sha }}
-
-      - name: Create required package.json
-        run: test -f package.json || echo '{}' >package.json
-
-      - name: Changelog
-        uses: scottbrenner/generate-changelog-action@master
-        id: Changelog
-
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: .
-
-      - name: Release
-        id: create-release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          body: |
-            ${{ steps.Changelog.outputs.changelog }}
-          draft: true
-          files: |
-            encointer-node-notee
-            encointer-client-notee
-
-  publish-runtimes:
-    name: Publish Runtimes
-    runs-on: ubuntu-22.04
-    needs: [ release, build-runtimes ]
-    strategy:
-      matrix:
-        runtime: [ "encointer-node-notee" ]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v4
-      - name: Set up Ruby 3
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0'
-
-      - name: Get runtime version
-        id: get-runtime-ver
-        run: |
-          ls
-          ls "${{ matrix.runtime }}-runtime-${{ github.sha }}"
-          runtime_ver="$(ruby -e 'require "./scripts/github/lib.rb"; puts get_runtime()')"
-          echo "Found version: >$runtime_ver<"
-          echo "runtime_ver={$runtime_ver}" >> $GITHUB_OUTPUT
-
-      - name: Upload compact ${{ matrix.runtime }} wasm
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.release.outputs.asset_upload_url }}
-          asset_path: "${{ matrix.runtime }}-runtime-${{ github.sha }}/encointer_node_notee_runtime.compact.wasm"
-          asset_name: encointer_node_notee_runtime-v${{ steps.get-runtime-ver.outputs.runtime_ver }}.compact.wasm
-          asset_content_type: application/wasm
-
-      - name: Upload compressed ${{ matrix.runtime }} wasm
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.release.outputs.asset_upload_url }}
-          asset_path: "${{ matrix.runtime }}-runtime-${{ github.sha }}/encointer_node_notee_runtime.compact.compressed.wasm"
-          asset_name: encointer_node_notee_runtime-v${{ steps.get-runtime-ver.outputs.runtime_ver }}.compact.compressed.wasm
-          asset_content_type: application/wasm
+#  release:
+#    name: Draft Release
+#    if: startsWith(github.ref, 'refs/tags/')
+#    runs-on: ubuntu-22.04
+#    needs: [ build, unit-tests, check, integration-test ]
+#    outputs:
+#      release_url: ${{ steps.create-release.outputs.html_url }}
+#      asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: Download Encointer Node
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: encointer-node-notee-${{ github.sha }}
+#
+#      - name: Download Encointer Client
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: encointer-client-notee-${{ github.sha }}
+#
+#      - name: Create required package.json
+#        run: test -f package.json || echo '{}' >package.json
+#
+#      - name: Changelog
+#        uses: scottbrenner/generate-changelog-action@master
+#        id: Changelog
+#
+#      - name: Display structure of downloaded files
+#        run: ls -R
+#        working-directory: .
+#
+#      - name: Release
+#        id: create-release
+#        uses: softprops/action-gh-release@v1
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          body: |
+#            ${{ steps.Changelog.outputs.changelog }}
+#          draft: true
+#          files: |
+#            encointer-node-notee
+#            encointer-client-notee
+#
+#  publish-runtimes:
+#    name: Publish Runtimes
+#    runs-on: ubuntu-22.04
+#    needs: [ release, build-runtimes ]
+#    strategy:
+#      matrix:
+#        runtime: [ "encointer-node-notee" ]
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: actions/download-artifact@v4
+#      - name: Set up Ruby 3
+#        uses: ruby/setup-ruby@v1
+#        with:
+#          ruby-version: '3.0'
+#
+#      - name: Get runtime version
+#        id: get-runtime-ver
+#        run: |
+#          ls
+#          ls "${{ matrix.runtime }}-runtime-${{ github.sha }}"
+#          runtime_ver="$(ruby -e 'require "./scripts/github/lib.rb"; puts get_runtime()')"
+#          echo "Found version: >$runtime_ver<"
+#          echo "runtime_ver={$runtime_ver}" >> $GITHUB_OUTPUT
+#
+#      - name: Upload compact ${{ matrix.runtime }} wasm
+#        uses: actions/upload-release-asset@v1
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          upload_url: ${{ needs.release.outputs.asset_upload_url }}
+#          asset_path: "${{ matrix.runtime }}-runtime-${{ github.sha }}/encointer_node_notee_runtime.compact.wasm"
+#          asset_name: encointer_node_notee_runtime-v${{ steps.get-runtime-ver.outputs.runtime_ver }}.compact.wasm
+#          asset_content_type: application/wasm
+#
+#      - name: Upload compressed ${{ matrix.runtime }} wasm
+#        uses: actions/upload-release-asset@v1
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          upload_url: ${{ needs.release.outputs.asset_upload_url }}
+#          asset_path: "${{ matrix.runtime }}-runtime-${{ github.sha }}/encointer_node_notee_runtime.compact.compressed.wasm"
+#          asset_name: encointer_node_notee_runtime-v${{ steps.get-runtime-ver.outputs.runtime_ver }}.compact.compressed.wasm
+#          asset_content_type: application/wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
           name: encointer-node-notee-4d0313f614223edf63cd0a5f0ad3d5ce16b81e6c
           # for debugging the integration tests, we can just download an image from a previous run
           github-token: ${{ github.token }}
-          run-id: 12772420910
+          run-id: 12787265993
 
       - name: download build artifacts
         uses: actions/download-artifact@v4
@@ -321,7 +321,7 @@ jobs:
           name: encointer-client-notee-4d0313f614223edf63cd0a5f0ad3d5ce16b81e6c
           # for debugging the integration tests, we can just download an image from a previous run
           github-token: ${{ github.token }}
-          run-id: 12772420910
+          run-id: 12787265993
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,13 +356,6 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache-node
           cache-to: type=local,dest=/tmp/.buildx-cache-node
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
-      - name: install py dependencies
-        run: ./scripts/install_python_deps.sh
-
       - name: Set up ipfs
         uses: ibnesayeed/setup-ipfs@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,39 +363,38 @@ jobs:
           run_daemon: true
 
       - name: start dev node
-        run:
+        run: |
           docker run -p 30333:30333 -p 9944:9944 -p 9615:9615 \
-          encointer-node-test \
-          --dev \
-          --enable-offchain-indexing true \
-          --rpc-methods unsafe \
-          -lencointer=debug,parity_ws=warn \
-          --rpc-external \
-
+            encointer-node-test \
+            --dev \
+            --enable-offchain-indexing=true \
+            --rpc-methods=unsafe \
+            -lencointer=debug,parity_ws=warn \
+            --rpc-external &
 
       - name: start faucet service
-        run:
+        run: |
           docker run -p 5000:5000 \
-          --add-host host.docker.internal:host-gateway \
-          encointer-client-test faucet.py \
-          -u ws://host.docker.internal \
-          --port 9944 &
+            --add-host host.docker.internal:host-gateway \
+            encointer-client-test faucet.py \
+            -u ws://host.docker.internal \
+            --port 9944 &
 
       - name: start phase accelerator service
-        run:
+        run: |
           docker run -p 5001:5000 \
-          --add-host host.docker.internal:host-gateway \
-          encointer-client-test phase.py \
-          -r ws://host.docker.internal \
-          --port 9944 --idle-blocks 3 &
+            --add-host host.docker.internal:host-gateway \
+            encointer-client-test phase.py \
+            -r ws://host.docker.internal \
+            --port 9944 --idle-blocks 3 &
 
       - name: Test ${{ matrix.test }}
-        run:
+        run: |
           docker run -p 5005:5000 \
-          --add-host host.docker.internal:host-gateway \
-          encointer-client-test ${{ matrix.test }} \
-          -r ws://host.docker.internal \
-          --port 9944 \
+            --add-host host.docker.internal:host-gateway \
+            encointer-client-test ${{ matrix.test }} \
+            -r ws://host.docker.internal \
+            --port 9944 \
 
   release:
     name: Draft Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,7 @@ jobs:
 
       - name: start phase accelerator service
         run: |
-          docker run -p 5001:5000 \
+          docker run -p 6000:5000 \
             --add-host host.docker.internal:host-gateway \
             encointer-client-test phase.py \
             -r ws://host.docker.internal \
@@ -387,7 +387,7 @@ jobs:
 
       - name: Test ${{ matrix.test }}
         run: |
-          docker run -p 5005:5000 \
+          docker run -p 7000:5000 \
             --add-host host.docker.internal:host-gateway \
             encointer-client-test ${{ matrix.test }} \
             -r ws://host.docker.internal \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
         test:
           - bootstrap_demo_community.py --signer //Bob --test
           - bot-community-test -f http://host.docker.internal:5000/api
-          # not working yet
+          # Todo: #386
           # - test-register-businesses -f http://host.docker.internal:5000/api
     steps:
       - uses: actions/checkout@v3
@@ -387,7 +387,7 @@ jobs:
 
       - name: start phase accelerator service
         run: |
-          docker run -p 6000:5000 \
+          docker run \
             --add-host host.docker.internal:host-gateway \
             encointer-client-test phase.py \
             -u ws://host.docker.internal \
@@ -395,7 +395,7 @@ jobs:
 
       - name: Test ${{ matrix.test }}
         run: |
-          docker run -p 7000:5000 \
+          docker run \
             --add-host host.docker.internal:host-gateway \
             encointer-client-test ${{ matrix.test }} \
             -u ws://host.docker.internal \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,10 +350,17 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Docker build client
-        run: docker build . -t encointer-client-test
+        run: |
+          docker build \
+            --cache-from=type=gha \
+            -t encointer-client-test .
 
       - name: Docker build node
-        run: docker build -f Dockerfile-node . -t encointer-node-test
+        run: |
+          docker build \
+          --cache-from=type=gha \
+          -f Dockerfile-node \
+          -t encointer-node-test . 
 
       - name: Set up ipfs
         uses: ibnesayeed/setup-ipfs@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,13 @@ env:
 jobs:
   cancel_previous_runs:
     name: Cancel Previous Runs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
@@ -63,7 +63,7 @@ jobs:
           path: target/release/encointer-client-notee
 
   build-try-runtime-and-benchmarks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
@@ -100,7 +100,7 @@ jobs:
 
   build-runtimes:
     name: Build Runtimes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         runtime: [ "encointer-node-notee" ]
@@ -176,7 +176,7 @@ jobs:
             ${{ steps.srtool_build.outputs.wasm_compressed }}
 
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
@@ -206,7 +206,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-22.04 ]
         rust: [ stable ]
         rust-target: [ x86_64-unknown-linux-gnu ]
         check: [ +nightly fmt --all -- --check, clippy -p encointer-client-notee ]
@@ -241,7 +241,7 @@ jobs:
         run: cargo ${{ matrix.check }}
 
   cargo-toml-fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: "tamasfe/taplo:0.7.0-alpine"
     steps:
       - uses: actions/checkout@v3
@@ -255,7 +255,7 @@ jobs:
 
   integration-test:
     name: ${{ matrix.test }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     strategy:
       matrix:
@@ -312,7 +312,7 @@ jobs:
 
   integration-test-docker:
     name: ${{ matrix.test }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     strategy:
       matrix:
@@ -320,6 +320,7 @@ jobs:
           - bootstrap_demo_community.py --signer //Bob --test,
           - bot-community-test -f http://host.docker.internal:5000/api,
           - test-register-businesses -f http://host.docker.internal:5000/api
+      ]
     steps:
       - uses: actions/checkout@v3
 
@@ -423,7 +424,7 @@ jobs:
   release:
     name: Draft Release
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ build, unit-tests, check, integration-test ]
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
@@ -467,7 +468,7 @@ jobs:
 
   publish-runtimes:
     name: Publish Runtimes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ release, build-runtimes ]
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Login to Dockerhub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Cache Docker layers
         uses: actions/cache@v3
         with:
@@ -343,25 +349,10 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Docker build client
-        id: docker_build
-        uses: docker/build-push-action@v3
-        with:
-          push: false
-          context: .
-          tags: encointer-client-test
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+        run: docker build . -t encointer-client-test
 
       - name: Docker build node
-        id: docker_build_node
-        uses: docker/build-push-action@v3
-        with:
-          file: Dockerfile-node
-          push: false
-          context: .
-          tags: encointer-node-test
-          cache-from: type=local,src=/tmp/.buildx-cache-node
-          cache-to: type=local,dest=/tmp/.buildx-cache-node
+        run: docker build -f Dockerfile-node . -t encointer-node-test
 
       - name: Set up ipfs
         uses: ibnesayeed/setup-ipfs@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,9 @@ jobs:
       - name: Setup Rust toolchain
         run: rustup show
 
-      - name: Cache Rust Dependecies
-        uses: actions/cache@v3
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-            enclave/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: "release"
 
       - name: Build
         run: cargo build --release
@@ -75,15 +69,9 @@ jobs:
       - name: Setup Rust toolchain
         run: rustup show
 
-      - name: Cache Rust Dependecies
-        uses: actions/cache@v3
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-            enclave/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: "release"
 
       - name: Build
         run: cargo build --release --features try-runtime,runtime-benchmarks
@@ -115,6 +103,7 @@ jobs:
           restore-keys: |
             srtool-target-${{ matrix.runtime }}-
             srtool-target-
+
       - name: Srtool build
         id: srtool_build
         uses: chevdor/srtool-actions@v0.9.2
@@ -188,15 +177,9 @@ jobs:
       - name: Setup Rust toolchain
         run: rustup show
 
-      - name: Cache Rust Dependecies
-        uses: actions/cache@v3
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-            enclave/target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: "debug"
 
       - name: cargo test
         run: cargo test --all
@@ -235,7 +218,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.rust-target }}-${{ matrix.check }}
+          shared-key: "debug"
 
       - name: ${{ matrix.check }}
         run: cargo ${{ matrix.check }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,123 @@ jobs:
         working-directory: ./scripts/ci
         run: source ./init_env.sh && ./${{ matrix.test }}
 
+  integration-test-docker:
+    name: ${{ matrix.test }}
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        test: [
+          bootstrap_demo_community.py --signer //Bob --test,
+          bot-community-test -f http://host.docker.internal:5000/api,
+          test-register-businesses -f http://host.docker.internal:5000/api
+        ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: encointer-node-notee-${{ github.sha }}
+
+      - name: download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: encointer-client-notee-${{ github.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache-node
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to Dockerhub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v3
+        with:
+          push: false
+          context: .
+          tags: encointer-client-test
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Build and push
+        id: docker_build_node
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile-node
+          push: false
+          context: .
+          tags: encointer-node-test
+          cache-from: type=local,src=/tmp/.buildx-cache-node
+          cache-to: type=local,dest=/tmp/.buildx-cache-node
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - name: install py dependencies
+        run: ./scripts/install_python_deps.sh
+
+      - name: Set up ipfs
+        uses: ibnesayeed/setup-ipfs@master
+        with:
+          run_daemon: true
+
+      - name: start dev node
+        run:
+          docker run -p 30333:30333 -p 9944:9944 -p 9615:9615 \
+          encointer-node-test \
+          --dev \
+          --enable-offchain-indexing true \
+          --rpc-methods unsafe \
+          -lencointer=debug,parity_ws=warn \
+          --rpc-external \
+
+
+      - name: start faucet service
+        run:
+          docker run -it -p 5000:5000 \
+          --add-host host.docker.internal:host-gateway \
+          encointer-client-test faucet.py \
+          -u ws://host.docker.internal \
+          --port 9944 &
+
+      - name: start phase accelerator service
+        run:
+          docker run -it -p 5001:5000 \
+          --add-host host.docker.internal:host-gateway \
+          encointer-client-test phase.py \
+          -r ws://host.docker.internal \
+          --port 9944 --idle-blocks 3 &
+
+      - name: Test ${{ matrix.test }}
+        run:
+          docker run -it -p 5005:5000 \
+          --add-host host.docker.internal:host-gateway \
+          encointer-client-test ${{ matrix.test }} \
+          -r ws://host.docker.internal \
+          --port 9944 \
+
   release:
     name: Draft Release
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,8 +301,8 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          - bootstrap_demo_community.py --signer //Bob --test,
-          - bot-community-test -f http://host.docker.internal:5000/api,
+          - bootstrap_demo_community.py --signer //Bob --test
+          - bot-community-test -f http://host.docker.internal:5000/api
           - test-register-businesses -f http://host.docker.internal:5000/api
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,7 @@ jobs:
           docker run -p 7000:5000 \
             --add-host host.docker.internal:host-gateway \
             encointer-client-test ${{ matrix.test }} \
-            -r ws://host.docker.internal \
+            -u ws://host.docker.internal \
             --port 9944 \
 
 #  release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,11 +316,10 @@ jobs:
     needs: build
     strategy:
       matrix:
-        test: [
-          bootstrap_demo_community.py --signer //Bob --test,
-          bot-community-test -f http://host.docker.internal:5000/api,
-          test-register-businesses -f http://host.docker.internal:5000/api
-        ]
+        test:
+          - bootstrap_demo_community.py --signer //Bob --test,
+          - bot-community-test -f http://host.docker.internal:5000/api,
+          - test-register-businesses -f http://host.docker.internal:5000/api
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build
     strategy:
+      fail-fast: false
       matrix:
         test:
           - bootstrap_demo_community.py --signer //Bob --test,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,13 +353,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Login to Dockerhub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Build and push
+      - name: Docker build client
         id: docker_build
         uses: docker/build-push-action@v3
         with:
@@ -369,7 +363,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
-      - name: Build and push
+      - name: Docker build node
         id: docker_build_node
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,277 +26,276 @@ jobs:
       - uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
-  #  build:
-  #    runs-on: ubuntu-22.04
-  #    steps:
-  #      - uses: actions/checkout@v3
-  #
-  #      - name: Install protoc
-  #        run: sudo apt-get install protobuf-compiler
-  #
-  #        # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-  #        # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
-  #      - name: Setup Rust toolchain
-  #        run: rustup show
-  #
-  #      - uses: Swatinem/rust-cache@v2
-  #        with:
-  #          shared-key: "release"
-  #
-  #      - name: Build
-  #        run: cargo build --release
-  #      - name: Upload node
-  #        uses: actions/upload-artifact@v4
-  #        with:
-  #          name: encointer-node-notee-${{ github.sha }}
-  #          path: target/release/encointer-node-notee
-  #      - name: Upload CLI client
-  #        uses: actions/upload-artifact@v4
-  #        with:
-  #          name: encointer-client-notee-${{ github.sha }}
-  #          path: target/release/encointer-client-notee
-  #
-  #  build-try-runtime-and-benchmarks:
-  #    runs-on: ubuntu-22.04
-  #    steps:
-  #      - uses: actions/checkout@v3
-  #
-  #      - name: Install protoc
-  #        run: sudo apt-get install protobuf-compiler
-  #
-  #        # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-  #        # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
-  #      - name: Setup Rust toolchain
-  #        run: rustup show
-  #
-  #      - uses: Swatinem/rust-cache@v2
-  #        with:
-  #          shared-key: "release"
-  #
-  #      - name: Build
-  #        run: cargo build --release --features try-runtime,runtime-benchmarks
-  #      - name: Upload node
-  #        uses: actions/upload-artifact@v4
-  #        with:
-  #          name: encointer-node-notee-try-runtime-and-benchmarks-${{ github.sha }}
-  #          path: target/release/encointer-node-notee
-  #      - name: Upload CLI client
-  #        uses: actions/upload-artifact@v4
-  #        with:
-  #          name: encointer-client-notee-try-runtime-and-benchmarks-${{ github.sha }}
-  #          path: target/release/encointer-client-notee
-  #
-  #  build-runtimes:
-  #    name: Build Runtimes
-  #    runs-on: ubuntu-22.04
-  #    strategy:
-  #      matrix:
-  #        runtime: [ "encointer-node-notee" ]
-  #    steps:
-  #      - uses: actions/checkout@v3
-  #
-  #      - name: Cache target dir
-  #        uses: actions/cache@v3
-  #        with:
-  #          path: "${{ github.workspace }}/runtime/target"
-  #          key: srtool-target-${{ matrix.runtime }}-${{ github.sha }}
-  #          restore-keys: |
-  #            srtool-target-${{ matrix.runtime }}-
-  #            srtool-target-
-  #
-  #      - name: Srtool build
-  #        id: srtool_build
-  #        uses: chevdor/srtool-actions@v0.9.2
-  #        with:
-  #          image: paritytech/srtool
-  #          tag: 1.77.0
-  #          chain: ${{ matrix.runtime }}
-  #          runtime_dir: runtime
-  #
-  #      - name: Summary
-  #        run: |
-  #          echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.runtime }}-srtool-digest.json
-  #          cat ${{ matrix.runtime }}-srtool-digest.json
-  #          echo "Compact Runtime: ${{ steps.srtool_build.outputs.wasm }}"
-  #          echo "Compressed Runtime: ${{ steps.srtool_build.outputs.wasm_compressed }}"
-  #      # We now get extra information thanks to subwasm
-  #      - name: Install subwasm
-  #        run: |
-  #          wget https://github.com/chevdor/subwasm/releases/download/v${{ env.SUBWASM_VERSION }}/subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
-  #          sudo dpkg -i subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
-  #          subwasm --version
-  #      - name: Show Runtime information
-  #        shell: bash
-  #        run: |
-  #          subwasm info ${{ steps.srtool_build.outputs.wasm }}
-  #          subwasm info ${{ steps.srtool_build.outputs.wasm_compressed }}
-  #          subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.runtime }}-info.json
-  #          subwasm --json info ${{ steps.srtool_build.outputs.wasm_compressed }} > ${{ matrix.runtime }}-compressed-info.json
-  #      - name: Extract the metadata
-  #        shell: bash
-  #        run: |
-  #          subwasm meta ${{ steps.srtool_build.outputs.wasm }}
-  #          subwasm --json meta ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.runtime }}-metadata.json
-  #      # This is unsupported it wants to diff the metadata with a running chain. i.e. wss://kusama-<matrix.chain>-rpc.parity.io
-  #      #      - name: Check the metadata diff
-  #      #        shell: bash
-  #      #        run: |
-  #      #          subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.chain }} > ${{ matrix.chain }}-diff.txt
-  #      #          cat ${{ matrix.chain }}-diff.txt
-  #
-  #      - name: Upload ${{ matrix.runtime }} srtool json
-  #        uses: actions/upload-artifact@v4
-  #        with:
-  #          name: ${{ matrix.runtime }}-srtool-json-${{ github.sha }}
-  #          path: |
-  #            ${{ matrix.runtime }}-srtool-digest.json
-  #            ${{ matrix.runtime }}-info.json
-  #            ${{ matrix.runtime }}-compressed-info.json
-  #            ${{ matrix.runtime }}-metadata.json
-  #      #            ${{ matrix.runtime }}-diff.txt
-  #
-  #
-  #      - name: Upload ${{ matrix.runtime }} runtime
-  #        uses: actions/upload-artifact@v4
-  #        with:
-  #          name: ${{ matrix.runtime }}-runtime-${{ github.sha }}
-  #          path: |
-  #            ${{ steps.srtool_build.outputs.wasm }}
-  #            ${{ steps.srtool_build.outputs.wasm_compressed }}
-  #
-  #  unit-tests:
-  #    runs-on: ubuntu-22.04
-  #    steps:
-  #      - uses: actions/checkout@v3
-  #
-  #      - name: Install protoc
-  #        run: sudo apt-get install protobuf-compiler
-  #
-  #        # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-  #        # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
-  #      - name: Setup Rust toolchain
-  #        run: rustup show
-  #
-  #      - uses: Swatinem/rust-cache@v2
-  #        with:
-  #          shared-key: "debug"
-  #
-  #      - name: cargo test
-  #        run: cargo test --all
-  #
-  #  check:
-  #    name: Rust check ${{ matrix.check }} (${{ matrix.rust-target }})
-  #    runs-on: ${{ matrix.os }}
-  #    strategy:
-  #      matrix:
-  #        os: [ ubuntu-22.04 ]
-  #        rust: [ stable ]
-  #        rust-target: [ x86_64-unknown-linux-gnu ]
-  #        check: [ +nightly fmt --all -- --check, clippy -p encointer-client-notee ]
-  #    env:
-  #      RUST_BACKTRACE: full
-  #      RUSTV: ${{ matrix.rust }}
-  #      TARGET: ${{ matrix.rust-target }}
-  #    steps:
-  #      - name: Install nightly toolchain
-  #        uses: actions-rs/toolchain@v1
-  #        with:
-  #          profile: minimal
-  #          toolchain: nightly
-  #          components: rustfmt
-  #
-  #      - name: Checkout
-  #        uses: actions/checkout@v3
-  #
-  #      - name: Install protoc
-  #        run: sudo apt-get install protobuf-compiler
-  #
-  #      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-  #      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
-  #      - name: Setup Rust toolchain
-  #        run: rustup show
-  #
-  #      - uses: Swatinem/rust-cache@v2
-  #        with:
-  #          shared-key: "debug"
-  #
-  #      - name: ${{ matrix.check }}
-  #        run: cargo ${{ matrix.check }}
-  #
-  #  cargo-toml-fmt:
-  #    runs-on: ubuntu-22.04
-  #    container: "tamasfe/taplo:0.7.0-alpine"
-  #    steps:
-  #      - uses: actions/checkout@v3
-  #
-  #      - name: Run Taplo fmt
-  #        run: taplo fmt --check
-  #
-  #      - name: Fail-fast; cancel other jobs
-  #        if: failure()
-  #        uses: andymckay/cancel-action@0.3
-  #
-  #  integration-test:
-  #    name: ${{ matrix.test }}
-  #    runs-on: ubuntu-22.04
-  #    needs: build
-  #    strategy:
-  #      matrix:
-  #        test: [ test_bootstrap_demo_community.sh, test_bot_community.sh, test_register_business.sh ]
-  #    steps:
-  #      - uses: actions/checkout@v3
-  #
-  #      - name: download build artifacts
-  #        uses: actions/download-artifact@v4
-  #        with:
-  #          name: encointer-node-notee-${{ github.sha }}
-  #
-  #      - name: download build artifacts
-  #        uses: actions/download-artifact@v4
-  #        with:
-  #          name: encointer-client-notee-${{ github.sha }}
-  #
-  #      - name: fix permissions of artifacts and move to original folder
-  #        run: |
-  #          chmod +x encointer-node-notee
-  #          chmod +x encointer-client-notee
-  #          mkdir -p target/release
-  #          mv encointer-*-notee target/release
-  #
-  #      - name: Set up Python
-  #        uses: actions/setup-python@v4
-  #        with:
-  #          python-version: 3.7
-  #      - name: install py dependencies
-  #        run: ./scripts/install_python_deps.sh
-  #
-  #      - name: Set up ipfs
-  #        uses: ibnesayeed/setup-ipfs@master
-  #        with:
-  #          run_daemon: true
-  #
-  #      - name: start dev node
-  #        run:
-  #          ./target/release/encointer-node-notee --tmp --dev --enable-offchain-indexing true --rpc-methods unsafe &
-  #
-  #      - name: start faucet service
-  #        run: |
-  #          cd client
-  #          python faucet.py &
-  #
-  #      - name: start phase accelerator service
-  #        run: |
-  #          cd client
-  #          python phase.py --idle-blocks 3 &
-  #
-  #      - name: Test ${{ matrix.test }}
-  #        working-directory: ./scripts/ci
-  #        run: source ./init_env.sh && ./${{ matrix.test }}
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install protoc
+        run: sudo apt-get install protobuf-compiler
+
+        # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
+        # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
+      - name: Setup Rust toolchain
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "release"
+
+      - name: Build
+        run: cargo build --release
+      - name: Upload node
+        uses: actions/upload-artifact@v4
+        with:
+          name: encointer-node-notee-${{ github.sha }}
+          path: target/release/encointer-node-notee
+      - name: Upload CLI client
+        uses: actions/upload-artifact@v4
+        with:
+          name: encointer-client-notee-${{ github.sha }}
+          path: target/release/encointer-client-notee
+
+  build-try-runtime-and-benchmarks:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install protoc
+        run: sudo apt-get install protobuf-compiler
+
+        # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
+        # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
+      - name: Setup Rust toolchain
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "release"
+
+      - name: Build
+        run: cargo build --release --features try-runtime,runtime-benchmarks
+      - name: Upload node
+        uses: actions/upload-artifact@v4
+        with:
+          name: encointer-node-notee-try-runtime-and-benchmarks-${{ github.sha }}
+          path: target/release/encointer-node-notee
+      - name: Upload CLI client
+        uses: actions/upload-artifact@v4
+        with:
+          name: encointer-client-notee-try-runtime-and-benchmarks-${{ github.sha }}
+          path: target/release/encointer-client-notee
+
+  build-runtimes:
+    name: Build Runtimes
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        runtime: [ "encointer-node-notee" ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache target dir
+        uses: actions/cache@v3
+        with:
+          path: "${{ github.workspace }}/runtime/target"
+          key: srtool-target-${{ matrix.runtime }}-${{ github.sha }}
+          restore-keys: |
+            srtool-target-${{ matrix.runtime }}-
+            srtool-target-
+
+      - name: Srtool build
+        id: srtool_build
+        uses: chevdor/srtool-actions@v0.9.2
+        with:
+          image: paritytech/srtool
+          tag: 1.77.0
+          chain: ${{ matrix.runtime }}
+          runtime_dir: runtime
+
+      - name: Summary
+        run: |
+          echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.runtime }}-srtool-digest.json
+          cat ${{ matrix.runtime }}-srtool-digest.json
+          echo "Compact Runtime: ${{ steps.srtool_build.outputs.wasm }}"
+          echo "Compressed Runtime: ${{ steps.srtool_build.outputs.wasm_compressed }}"
+      # We now get extra information thanks to subwasm
+      - name: Install subwasm
+        run: |
+          wget https://github.com/chevdor/subwasm/releases/download/v${{ env.SUBWASM_VERSION }}/subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+          sudo dpkg -i subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+          subwasm --version
+      - name: Show Runtime information
+        shell: bash
+        run: |
+          subwasm info ${{ steps.srtool_build.outputs.wasm }}
+          subwasm info ${{ steps.srtool_build.outputs.wasm_compressed }}
+          subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.runtime }}-info.json
+          subwasm --json info ${{ steps.srtool_build.outputs.wasm_compressed }} > ${{ matrix.runtime }}-compressed-info.json
+      - name: Extract the metadata
+        shell: bash
+        run: |
+          subwasm meta ${{ steps.srtool_build.outputs.wasm }}
+          subwasm --json meta ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.runtime }}-metadata.json
+      # This is unsupported it wants to diff the metadata with a running chain. i.e. wss://kusama-<matrix.chain>-rpc.parity.io
+      #      - name: Check the metadata diff
+      #        shell: bash
+      #        run: |
+      #          subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.chain }} > ${{ matrix.chain }}-diff.txt
+      #          cat ${{ matrix.chain }}-diff.txt
+
+      - name: Upload ${{ matrix.runtime }} srtool json
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.runtime }}-srtool-json-${{ github.sha }}
+          path: |
+            ${{ matrix.runtime }}-srtool-digest.json
+            ${{ matrix.runtime }}-info.json
+            ${{ matrix.runtime }}-compressed-info.json
+            ${{ matrix.runtime }}-metadata.json
+      #            ${{ matrix.runtime }}-diff.txt
+
+      - name: Upload ${{ matrix.runtime }} runtime
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.runtime }}-runtime-${{ github.sha }}
+          path: |
+            ${{ steps.srtool_build.outputs.wasm }}
+            ${{ steps.srtool_build.outputs.wasm_compressed }}
+
+  unit-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install protoc
+        run: sudo apt-get install protobuf-compiler
+
+        # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
+        # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
+      - name: Setup Rust toolchain
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      - name: cargo test
+        run: cargo test --all
+
+  check:
+    name: Rust check ${{ matrix.check }} (${{ matrix.rust-target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04 ]
+        rust: [ stable ]
+        rust-target: [ x86_64-unknown-linux-gnu ]
+        check: [ +nightly fmt --all -- --check, clippy -p encointer-client-notee ]
+    env:
+      RUST_BACKTRACE: full
+      RUSTV: ${{ matrix.rust }}
+      TARGET: ${{ matrix.rust-target }}
+    steps:
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install protoc
+        run: sudo apt-get install protobuf-compiler
+
+      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
+      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
+      - name: Setup Rust toolchain
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      - name: ${{ matrix.check }}
+        run: cargo ${{ matrix.check }}
+
+  cargo-toml-fmt:
+    runs-on: ubuntu-22.04
+    container: "tamasfe/taplo:0.7.0-alpine"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run Taplo fmt
+        run: taplo fmt --check
+
+      - name: Fail-fast; cancel other jobs
+        if: failure()
+        uses: andymckay/cancel-action@0.3
+
+  integration-test:
+    name: ${{ matrix.test }}
+    runs-on: ubuntu-22.04
+    needs: build
+    strategy:
+      matrix:
+        test: [ test_bootstrap_demo_community.sh, test_bot_community.sh, test_register_business.sh ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: encointer-node-notee-${{ github.sha }}
+
+      - name: download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: encointer-client-notee-${{ github.sha }}
+
+      - name: fix permissions of artifacts and move to original folder
+        run: |
+          chmod +x encointer-node-notee
+          chmod +x encointer-client-notee
+          mkdir -p target/release
+          mv encointer-*-notee target/release
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - name: install py dependencies
+        run: ./scripts/install_python_deps.sh
+
+      - name: Set up ipfs
+        uses: ibnesayeed/setup-ipfs@master
+        with:
+          run_daemon: true
+
+      - name: start dev node
+        run:
+          ./target/release/encointer-node-notee --tmp --dev --enable-offchain-indexing true --rpc-methods unsafe &
+
+      - name: start faucet service
+        run: |
+          cd client
+          python faucet.py &
+
+      - name: start phase accelerator service
+        run: |
+          cd client
+          python phase.py --idle-blocks 3 &
+
+      - name: Test ${{ matrix.test }}
+        working-directory: ./scripts/ci
+        run: source ./init_env.sh && ./${{ matrix.test }}
 
   integration-test-docker:
     name: ${{ matrix.test }}
     runs-on: ubuntu-22.04
-    #    needs: build
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -311,18 +310,20 @@ jobs:
       - name: download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: encointer-node-notee-4d0313f614223edf63cd0a5f0ad3d5ce16b81e6c
+          name: encointer-node-notee-${{ github.sha }}
           # for debugging the integration tests, we can just download an image from a previous run
-          github-token: ${{ github.token }}
-          run-id: 12787265993
+      #          name: encointer-node-notee-4d0313f614223edf63cd0a5f0ad3d5ce16b81e6c
+      #          github-token: ${{ github.token }}
+      #          run-id: 12787265993
 
       - name: download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: encointer-client-notee-4d0313f614223edf63cd0a5f0ad3d5ce16b81e6c
+          name: encointer-client-notee-${{ github.sha }}
           # for debugging the integration tests, we can just download an image from a previous run
-          github-token: ${{ github.token }}
-          run-id: 12787265993
+      #          name: encointer-client-notee-4d0313f614223edf63cd0a5f0ad3d5ce16b81e6c
+      #          github-token: ${{ github.token }}
+      #          run-id: 12787265993
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -401,91 +402,91 @@ jobs:
             -u ws://host.docker.internal \
             --port 9944 \
 
-#  release:
-#    name: Draft Release
-#    if: startsWith(github.ref, 'refs/tags/')
-#    runs-on: ubuntu-22.04
-#    needs: [ build, unit-tests, check, integration-test ]
-#    outputs:
-#      release_url: ${{ steps.create-release.outputs.html_url }}
-#      asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: Download Encointer Node
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: encointer-node-notee-${{ github.sha }}
-#
-#      - name: Download Encointer Client
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: encointer-client-notee-${{ github.sha }}
-#
-#      - name: Create required package.json
-#        run: test -f package.json || echo '{}' >package.json
-#
-#      - name: Changelog
-#        uses: scottbrenner/generate-changelog-action@master
-#        id: Changelog
-#
-#      - name: Display structure of downloaded files
-#        run: ls -R
-#        working-directory: .
-#
-#      - name: Release
-#        id: create-release
-#        uses: softprops/action-gh-release@v1
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          body: |
-#            ${{ steps.Changelog.outputs.changelog }}
-#          draft: true
-#          files: |
-#            encointer-node-notee
-#            encointer-client-notee
-#
-#  publish-runtimes:
-#    name: Publish Runtimes
-#    runs-on: ubuntu-22.04
-#    needs: [ release, build-runtimes ]
-#    strategy:
-#      matrix:
-#        runtime: [ "encointer-node-notee" ]
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: actions/download-artifact@v4
-#      - name: Set up Ruby 3
-#        uses: ruby/setup-ruby@v1
-#        with:
-#          ruby-version: '3.0'
-#
-#      - name: Get runtime version
-#        id: get-runtime-ver
-#        run: |
-#          ls
-#          ls "${{ matrix.runtime }}-runtime-${{ github.sha }}"
-#          runtime_ver="$(ruby -e 'require "./scripts/github/lib.rb"; puts get_runtime()')"
-#          echo "Found version: >$runtime_ver<"
-#          echo "runtime_ver={$runtime_ver}" >> $GITHUB_OUTPUT
-#
-#      - name: Upload compact ${{ matrix.runtime }} wasm
-#        uses: actions/upload-release-asset@v1
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          upload_url: ${{ needs.release.outputs.asset_upload_url }}
-#          asset_path: "${{ matrix.runtime }}-runtime-${{ github.sha }}/encointer_node_notee_runtime.compact.wasm"
-#          asset_name: encointer_node_notee_runtime-v${{ steps.get-runtime-ver.outputs.runtime_ver }}.compact.wasm
-#          asset_content_type: application/wasm
-#
-#      - name: Upload compressed ${{ matrix.runtime }} wasm
-#        uses: actions/upload-release-asset@v1
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          upload_url: ${{ needs.release.outputs.asset_upload_url }}
-#          asset_path: "${{ matrix.runtime }}-runtime-${{ github.sha }}/encointer_node_notee_runtime.compact.compressed.wasm"
-#          asset_name: encointer_node_notee_runtime-v${{ steps.get-runtime-ver.outputs.runtime_ver }}.compact.compressed.wasm
-#          asset_content_type: application/wasm
+  release:
+    name: Draft Release
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-22.04
+    needs: [ build, unit-tests, check, integration-test ]
+    outputs:
+      release_url: ${{ steps.create-release.outputs.html_url }}
+      asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download Encointer Node
+        uses: actions/download-artifact@v4
+        with:
+          name: encointer-node-notee-${{ github.sha }}
+
+      - name: Download Encointer Client
+        uses: actions/download-artifact@v4
+        with:
+          name: encointer-client-notee-${{ github.sha }}
+
+      - name: Create required package.json
+        run: test -f package.json || echo '{}' >package.json
+
+      - name: Changelog
+        uses: scottbrenner/generate-changelog-action@master
+        id: Changelog
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: .
+
+      - name: Release
+        id: create-release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          body: |
+            ${{ steps.Changelog.outputs.changelog }}
+          draft: true
+          files: |
+            encointer-node-notee
+            encointer-client-notee
+
+  publish-runtimes:
+    name: Publish Runtimes
+    runs-on: ubuntu-22.04
+    needs: [ release, build-runtimes ]
+    strategy:
+      matrix:
+        runtime: [ "encointer-node-notee" ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v4
+      - name: Set up Ruby 3
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+
+      - name: Get runtime version
+        id: get-runtime-ver
+        run: |
+          ls
+          ls "${{ matrix.runtime }}-runtime-${{ github.sha }}"
+          runtime_ver="$(ruby -e 'require "./scripts/github/lib.rb"; puts get_runtime()')"
+          echo "Found version: >$runtime_ver<"
+          echo "runtime_ver={$runtime_ver}" >> $GITHUB_OUTPUT
+
+      - name: Upload compact ${{ matrix.runtime }} wasm
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.asset_upload_url }}
+          asset_path: "${{ matrix.runtime }}-runtime-${{ github.sha }}/encointer_node_notee_runtime.compact.wasm"
+          asset_name: encointer_node_notee_runtime-v${{ steps.get-runtime-ver.outputs.runtime_ver }}.compact.wasm
+          asset_content_type: application/wasm
+
+      - name: Upload compressed ${{ matrix.runtime }} wasm
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.asset_upload_url }}
+          asset_path: "${{ matrix.runtime }}-runtime-${{ github.sha }}/encointer_node_notee_runtime.compact.compressed.wasm"
+          asset_name: encointer_node_notee_runtime-v${{ steps.get-runtime-ver.outputs.runtime_ver }}.compact.compressed.wasm
+          asset_content_type: application/wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,7 @@ jobs:
           docker run -p 6000:5000 \
             --add-host host.docker.internal:host-gateway \
             encointer-client-test phase.py \
-            -r ws://host.docker.internal \
+            -u ws://host.docker.internal \
             --port 9944 --idle-blocks 3 &
 
       - name: Test ${{ matrix.test }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,8 @@ jobs:
         test:
           - bootstrap_demo_community.py --signer //Bob --test
           - bot-community-test -f http://host.docker.internal:5000/api
-          - test-register-businesses -f http://host.docker.internal:5000/api
+          # not working yet
+          # - test-register-businesses -f http://host.docker.internal:5000/api
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,7 +405,7 @@ jobs:
 
       - name: start faucet service
         run:
-          docker run -it -p 5000:5000 \
+          docker run -p 5000:5000 \
           --add-host host.docker.internal:host-gateway \
           encointer-client-test faucet.py \
           -u ws://host.docker.internal \
@@ -413,7 +413,7 @@ jobs:
 
       - name: start phase accelerator service
         run:
-          docker run -it -p 5001:5000 \
+          docker run -p 5001:5000 \
           --add-host host.docker.internal:host-gateway \
           encointer-client-test phase.py \
           -r ws://host.docker.internal \
@@ -421,7 +421,7 @@ jobs:
 
       - name: Test ${{ matrix.test }}
         run:
-          docker run -it -p 5005:5000 \
+          docker run -p 5005:5000 \
           --add-host host.docker.internal:host-gateway \
           encointer-client-test ${{ matrix.test }} \
           -r ws://host.docker.internal \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,12 +310,18 @@ jobs:
       - name: download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: encointer-node-notee-${{ github.sha }}
+          name: encointer-node-notee-4d0313f614223edf63cd0a5f0ad3d5ce16b81e6c
+          # for debugging the integration tests, we can just download an image from a previous run
+          github-token: ${{ github.token }}
+          run-id: 12772420910
 
       - name: download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: encointer-client-notee-${{ github.sha }}
+          name: encointer-client-notee-4d0313f614223edf63cd0a5f0ad3d5ce16b81e6c
+          # for debugging the integration tests, we can just download an image from a previous run
+          github-token: ${{ github.token }}
+          run-id: 12772420910
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,6 @@ jobs:
           - bootstrap_demo_community.py --signer //Bob --test,
           - bot-community-test -f http://host.docker.internal:5000/api,
           - test-register-businesses -f http://host.docker.internal:5000/api
-      ]
     steps:
       - uses: actions/checkout@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 LABEL description="This is the 2nd stage: a very small image where we copy the Substrate binary."
 
-RUN apt-get update && \ 
+RUN apt-get update && \
 apt-get install -y jq python3 python3-pip
 
 RUN python3 -m pip install --upgrade pip
@@ -18,7 +18,7 @@ RUN mv /usr/share/ca* /tmp && \
 WORKDIR /
 
 COPY scripts/docker/entryscript.sh /
-COPY target/release/encointer-client-notee /
+COPY encointer-client-notee /
 
 #COPY ./scripts/healthcheck9933.sh /usr/local/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ COPY client/py_client /py_client
 COPY client/test-data /test-data
 
 # all python scripts (some of them aren supported by the entryfile.sh yet).
-COPY client/bazaar.py /
 COPY client/bootstrap_demo_community.py /
 COPY client/bot-community.py /
 COPY client/bot-stats-golden.csv /
@@ -35,11 +34,7 @@ COPY client/cli.py /
 COPY client/faucet.py /
 COPY client/phase.py /
 COPY client/typedefs.json /
-COPY client/publish-assets.py /
-COPY client/register-business-simple.py /
 COPY client/register-random-businesses-and-offerings.py /
-COPY client/upload-folder-to-ipfs-and-return-cid.py /
-COPY client/upload-image-to-ipfs-and-return-cid.py /
 
 RUN chmod +x /encointer-client-notee
 #RUN chmod +x /usr/local/bin/healthcheck9933.sh
@@ -53,7 +48,7 @@ RUN ldd /encointer-client-notee && \
 #	rm -rf /usr/bin /usr/sbin /usr/share/man
 
 #USER encointer
-EXPOSE 30333 9933 9944 9615
+EXPOSE 30333 9933 9944 9615 5000
 VOLUME ["/data"]
 
 ENTRYPOINT ["/entryscript.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,28 @@ COPY encointer-client-notee /
 
 RUN mkdir /client
 COPY client/py_client /py_client
-COPY client/bootstrap_demo_community.py /
-COPY client/cli.py /
 COPY client/test-data /test-data
+
+# all python scripts
+COPY client/batch.py /
+COPY client/bazaar.py /
+COPY client/bootstrap_demo_community.py /
+COPY client/bot-community.py /
+COPY client/bot-stats-golden.csv /
+COPY client/cli.py /
+COPY client/dump-accounts.py /
+COPY client/dump_drips.py /
+COPY client/dump_teleports.py /
+COPY client/faucet.py /
+COPY client/fetch-account-history.py /
+COPY client/invoice.py /
+COPY client/phase.py /
+COPY client/publish-assets.py /
+COPY client/register-business-simple.py /
+COPY client/register-random-businesses-and-offerings.py /
+COPY client/upload-folder-to-ipfs-and-return-cid.py /
+COPY client/upload-image-to-ipfs-and-return-cid.py /
+COPY client/voucher.py /
 
 RUN chmod +x /encointer-client-notee
 #RUN chmod +x /usr/local/bin/healthcheck9933.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mv /usr/share/ca* /tmp && \
 WORKDIR /
 
 COPY scripts/docker/entryscript.sh /
-COPY encointer-client-notee /
+COPY target/release/encointer-client-notee /
 
 #COPY ./scripts/healthcheck9933.sh /usr/local/bin
 
@@ -26,26 +26,20 @@ RUN mkdir /client
 COPY client/py_client /py_client
 COPY client/test-data /test-data
 
-# all python scripts
-COPY client/batch.py /
+# all python scripts (some of them aren supported by the entryfile.sh yet).
 COPY client/bazaar.py /
 COPY client/bootstrap_demo_community.py /
 COPY client/bot-community.py /
 COPY client/bot-stats-golden.csv /
 COPY client/cli.py /
-COPY client/dump-accounts.py /
-COPY client/dump_drips.py /
-COPY client/dump_teleports.py /
 COPY client/faucet.py /
-COPY client/fetch-account-history.py /
-COPY client/invoice.py /
 COPY client/phase.py /
+COPY client/typedefs.json /
 COPY client/publish-assets.py /
 COPY client/register-business-simple.py /
 COPY client/register-random-businesses-and-offerings.py /
 COPY client/upload-folder-to-ipfs-and-return-cid.py /
 COPY client/upload-image-to-ipfs-and-return-cid.py /
-COPY client/voucher.py /
 
 RUN chmod +x /encointer-client-notee
 #RUN chmod +x /usr/local/bin/healthcheck9933.sh

--- a/client/bazaar.py
+++ b/client/bazaar.py
@@ -30,25 +30,25 @@ import tempfile
 import os
 
 
-
-
 @click.group()
-@click.option('--cid', required=True, help='the community identifier of the community you want to register your business in (11 digits).')
+@click.option('--cid', required=True,
+              help='the community identifier of the community you want to register your business in (11 digits).')
 @click.option('--bizaccount', required=False, help='the account of the owner in ss58 format or raw_seed.')
 @click.option('--price', default='0', help='price of your offering.')
-@click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
+@click.option('--client', default='../target/release/encointer-client-notee',
+              help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
-@click.option('-r', '--remote_chain', default=None, help='choose remote chain: gesell.')
+@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain.')
 @click.pass_context
-def cli(ctx, client, port, cid, bizaccount, price, remote_chain):
+def cli(ctx, client, port, cid, bizaccount, price, url):
     ctx.ensure_object(dict)
-    cl = set_local_or_remote_chain(client, port, remote_chain)
+    cl = set_local_or_remote_chain(client, port, url)
     ctx.obj['client'] = cl
     ctx.obj['port'] = port
     ctx.obj['cid'] = cid
     ctx.obj['bizaccount'] = bizaccount
     # ctx.obj['ipfs_local'] = ipfs_local
-    ctx.obj['remote_chain'] = remote_chain
+    ctx.obj['url'] = url
     ctx.obj['price'] = price
 
 
@@ -132,6 +132,7 @@ def register_offering(ctx, specfile):
     except:
         print("error creating an offering entry")
 
+
 @cli.command()
 @click.pass_obj
 def list_businesses(ctx):
@@ -142,6 +143,7 @@ def list_businesses(ctx):
     """
     client = ctx['client']
     print(client.list_businesses(ctx['cid']))
+
 
 @cli.command()
 @click.pass_obj
@@ -158,6 +160,7 @@ def list_offerings(ctx):
         print(client.list_offerings(ctx['cid']))
     else:
         print(client.list_offerings_for_business(ctx['cid'], ctx["bizaccount"]))
+
 
 if __name__ == '__main__':
     cli(obj={})

--- a/client/bazaar.py
+++ b/client/bazaar.py
@@ -38,7 +38,7 @@ import os
 @click.option('--client', default='../target/release/encointer-client-notee',
               help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
-@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain.')
+@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain, or `gesell` alternatively.')
 @click.pass_context
 def cli(ctx, client, port, cid, bizaccount, price, url):
     ctx.ensure_object(dict)

--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -405,7 +405,7 @@ def test_democracy(client, cid):
 @click.option('--client', default='../target/release/encointer-client-notee',
               help='Client binary to communicate with the chain.')
 @click.option('--signer', help='optional account keypair creating the community')
-@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain.')
+@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain, or `gesell` alternatively.')
 @click.option('-p', '--port', default='9944', help='ws-port of the chain.')
 @click.option('-l', '--ipfs-local', is_flag=True, help='if set, local ipfs node is used.')
 @click.option('-s', '--spec-file', default=f'{TEST_DATA_DIR}{TEST_LOCATIONS_MEDITERRANEAN}',

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -51,18 +51,18 @@ NUMBER_OF_ENDORSEMENTS_PER_REGISTRATION = 10
 @click.option('--client', default='../target/release/encointer-client-notee',
               help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
+@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain.')
 @click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used.')
-@click.option('-r', '--remote_chain', default=None, help='choose one of the remote chains: gesell.')
 @click.option('-f', '--faucet_url', default='http://localhost:5000/api',
               help='url for the faucet (only needed for test/benchmark cmd)')
 @click.pass_context
-def cli(ctx, client, port, ipfs_local, remote_chain, faucet_url):
+def cli(ctx, client, port, ipfs_local, url, faucet_url):
     ctx.ensure_object(dict)
-    cl = set_local_or_remote_chain(client, port, remote_chain)
+    cl = set_local_or_remote_chain(client, port, url)
     ctx.obj['client'] = cl
     ctx.obj['port'] = port
     ctx.obj['ipfs_local'] = ipfs_local
-    ctx.obj['remote_chain'] = remote_chain
+    ctx.obj['url'] = url
     ctx.obj['faucet_url'] = faucet_url
 
 

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -53,20 +53,24 @@ NUMBER_OF_ENDORSEMENTS_PER_REGISTRATION = 10
 @click.option('--port', default='9944', help='ws-port of the chain.')
 @click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used.')
 @click.option('-r', '--remote_chain', default=None, help='choose one of the remote chains: gesell.')
+@click.option('-f', '--faucet_url', default='http://localhost:5000/api',
+              help='url for the faucet (only needed for test/benchmark cmd)')
 @click.pass_context
-def cli(ctx, client, port, ipfs_local, remote_chain):
+def cli(ctx, client, port, ipfs_local, remote_chain, faucet_url):
     ctx.ensure_object(dict)
     cl = set_local_or_remote_chain(client, port, remote_chain)
     ctx.obj['client'] = cl
     ctx.obj['port'] = port
     ctx.obj['ipfs_local'] = ipfs_local
     ctx.obj['remote_chain'] = remote_chain
+    ctx.obj['faucet_url'] = faucet_url
 
 
 @cli.command()
 @click.pass_obj
 def init(ctx):
     client = ctx['client']
+    faucet_url = ctx['faucet_url']
     purge_keystore_prompt()
 
     root_dir = os.path.realpath(ASSETS_PATH)
@@ -76,7 +80,7 @@ def init(ctx):
     except:
         print("add image to ipfs failed")
     print('initializing community')
-    b = init_bootstrappers(client)
+    b = init_bootstrappers(client, faucet_url)
     client.await_block()
     specfile = random_community_spec(b, ipfs_cid, NUMBER_OF_LOCATIONS)
     print(f'generated community spec: {specfile} first bootstrapper {b[0]}')
@@ -103,10 +107,10 @@ def purge_communities():
 @cli.command()
 @click.pass_obj
 def execute_current_phase(ctx):
-    return _execute_current_phase(ctx['client'])
+    return _execute_current_phase(ctx['client'], ctx['faucet_url'])
 
 
-def _execute_current_phase(client: Client):
+def _execute_current_phase(client: Client, faucet_url: str):
     client = client
     cid = read_cid()
     phase = client.get_phase()
@@ -124,12 +128,12 @@ def _execute_current_phase(client: Client):
 
         total_supply = write_current_stats(client, accounts, cid)
         if total_supply > 0:
-            init_new_community_members(client, cid, len(accounts))
+            init_new_community_members(client, cid, len(accounts), faucet_url=faucet_url)
 
         # updated account list with new community members
         accounts = client.list_accounts()
 
-        register_participants(client, accounts, cid)
+        register_participants(client, accounts, cid, faucet_url=faucet_url)
         client.await_block()
 
     if phase == "Assigning":
@@ -153,9 +157,10 @@ def _execute_current_phase(client: Client):
 @click.pass_obj
 def benchmark(ctx):
     py_client = ctx['client']
+    faucet_url = ctx['faucet_url']
     print('will grow population forever')
     while True:
-        phase = _execute_current_phase(py_client)
+        phase = _execute_current_phase(py_client, faucet_url=faucet_url)
         while phase == py_client.get_phase():
             print("awaiting next phase...")
             py_client.await_block()
@@ -165,18 +170,19 @@ def benchmark(ctx):
 @click.pass_obj
 def test(ctx):
     py_client = ctx['client']
+    faucet_url = ctx['faucet_url']
     print('will grow population for fixed number of ceremonies')
     for i in range(3 * 2 + 1):
-        phase = _execute_current_phase(py_client)
+        phase = _execute_current_phase(py_client, faucet_url=faucet_url)
         while phase == py_client.get_phase():
             print("awaiting next phase...")
             py_client.await_block()
 
 
-def init_bootstrappers(client: Client):
+def init_bootstrappers(client: Client, faucet_url: str):
     bootstrappers = client.create_accounts(10)
     print('created bootstrappers: ' + ' '.join(bootstrappers))
-    client.faucet(bootstrappers)
+    client.faucet(bootstrappers, faucet_url=faucet_url)
     client.await_block()
     return bootstrappers
 
@@ -260,7 +266,12 @@ def write_current_stats(client: Client, accounts, cid):
     return total
 
 
-def init_new_community_members(client: Client, cid: str, current_community_size: int):
+def init_new_community_members(
+        client: Client,
+        cid: str,
+        current_community_size: int,
+        faucet_url: str
+):
     """ Initializes new community members based on the `current_community_size` and the amount of endorsements we can
         perform.
 
@@ -285,7 +296,7 @@ def init_new_community_members(client: Client, cid: str, current_community_size:
 
     new_members = newbies + endorsees
 
-    client.faucet(new_members)
+    client.faucet(new_members, faucet_url=faucet_url)
     client.await_block()
 
     print(f'Fauceted new community members {len(new_members)}')
@@ -293,7 +304,7 @@ def init_new_community_members(client: Client, cid: str, current_community_size:
     return new_members
 
 
-def register_participants(client: Client, accounts, cid):
+def register_participants(client: Client, accounts, cid, faucet_url: str):
     print(f'registering {len(accounts)} participants')
     need_refunding = []
     for p in accounts:
@@ -307,7 +318,7 @@ def register_participants(client: Client, accounts, cid):
 
     if len(need_refunding) > 0:
         print(f'the following accounts are out of funds and will be refunded {need_refunding}')
-        client.faucet(need_refunding)
+        client.faucet(need_refunding, faucet_url=faucet_url)
 
         client.await_block()
 

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -51,7 +51,7 @@ NUMBER_OF_ENDORSEMENTS_PER_REGISTRATION = 10
 @click.option('--client', default='../target/release/encointer-client-notee',
               help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
-@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain.')
+@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain, or `gesell` alternatively.')
 @click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used.')
 @click.option('-f', '--faucet_url', default='http://localhost:5000/api',
               help='url for the faucet (only needed for test/benchmark cmd)')

--- a/client/faucet.py
+++ b/client/faucet.py
@@ -59,7 +59,8 @@ def faucet_service():
 @click.option('-p', '--port', default='9944', help='ws-port of the chain.')
 def main(client, url, port):
     CLIENT = Client(rust_client=client, node_url=url, port=port)
-    app.run()
+    # make the app listen from outside the docker container
+    app.run(host="0.0.0.0")
 
 
 if __name__ == "__main__":

--- a/client/faucet.py
+++ b/client/faucet.py
@@ -12,11 +12,13 @@ import flask
 from flask import request, jsonify
 import subprocess
 from time import sleep
+import click
+
 from py_client.client import Client
 
 app = flask.Flask(__name__)
 app.config['DEBUG'] = True
-CLIENT = Client()
+CLIENT = None
 
 
 def faucet(accounts):
@@ -50,4 +52,15 @@ def faucet_service():
         return "no accounts provided to drip to\n"
 
 
-app.run()
+@click.command()
+@click.option('--client', default='../target/release/encointer-client-notee',
+              help='Client binary to communicate with the chain.')
+@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain.')
+@click.option('-p', '--port', default='9944', help='ws-port of the chain.')
+def main(client, url, port):
+    CLIENT = Client(rust_client=client, node_url=url, port=port)
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/client/faucet.py
+++ b/client/faucet.py
@@ -22,6 +22,9 @@ CLIENT = None
 
 
 def faucet(accounts):
+    if CLIENT is None:
+        raise RuntimeError("CLIENT is not initialized.")
+
     for x in range(0, 1):  # try multiple
         try:
             CLIENT.faucet(accounts, is_faucet=True)
@@ -58,6 +61,7 @@ def faucet_service():
 @click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain.')
 @click.option('-p', '--port', default='9944', help='ws-port of the chain.')
 def main(client, url, port):
+    global CLIENT  # Declare CLIENT as global to modify the global variable
     CLIENT = Client(rust_client=client, node_url=url, port=port)
     # make the app listen from outside the docker container
     app.run(host="0.0.0.0")

--- a/client/phase.py
+++ b/client/phase.py
@@ -22,20 +22,22 @@ INTRINSIC_EVENTS = 2
 
 global patience
 
+
 @click.command()
-@click.option('-r', '--remote-chain', default=None, help='choose one of the remote chains: gesell.')
-@click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
+@click.option('-r', '--remote-chain', default='ws://127.0.0.1',
+              help='choose one of the remote chains: gesell, or the url')
+@click.option('--client', default='../target/release/encointer-client-notee',
+              help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
 @click.option('--idle-blocks', default=10, help='how many idle blocks to await before moving to next phase')
 def main(remote_chain, client, port, idle_blocks):
-    localhost = None
     client = set_local_or_remote_chain(client, port, remote_chain)
     global COUNT, patience
     patience = idle_blocks
     with open('typedefs.json') as f:
         custom_type_registry = json.load(f)
     substrate = SubstrateInterface(
-        url= f"wss://gesell.encointer.org:{443}" if localhost is not None else f"ws://127.0.0.1:{port}",
+        url=get_node_url(node_url=remote_chain, port=port),
         ss58_format=42,
         type_registry_preset='substrate-node-template',
         type_registry=custom_type_registry
@@ -56,6 +58,13 @@ def subscription_handler(event_count, update_nr, subscription_id):
         COUNT += 1
     else:
         COUNT = 0
+
+
+def get_node_url(node_url, port):
+    if node_url == "gesell":
+        return f"wss://gesell.encointer.org:{443}"
+    else:
+        return f"{node_url}:{port}"
 
 
 if __name__ == '__main__':

--- a/client/phase.py
+++ b/client/phase.py
@@ -24,20 +24,19 @@ global patience
 
 
 @click.command()
-@click.option('-r', '--remote-chain', default='ws://127.0.0.1',
-              help='choose one of the remote chains: gesell, or the url')
 @click.option('--client', default='../target/release/encointer-client-notee',
               help='Client binary to communicate with the chain.')
+@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
 @click.option('--idle-blocks', default=10, help='how many idle blocks to await before moving to next phase')
-def main(remote_chain, client, port, idle_blocks):
-    client = set_local_or_remote_chain(client, port, remote_chain)
+def main(client, url, port, idle_blocks):
+    client = set_local_or_remote_chain(client, port, url)
     global COUNT, patience
     patience = idle_blocks
     with open('typedefs.json') as f:
         custom_type_registry = json.load(f)
     substrate = SubstrateInterface(
-        url=get_node_url(node_url=remote_chain, port=port),
+        url=get_node_url(node_url=url, port=port),
         ss58_format=42,
         type_registry_preset='substrate-node-template',
         type_registry=custom_type_registry

--- a/client/phase.py
+++ b/client/phase.py
@@ -26,7 +26,7 @@ global patience
 @click.command()
 @click.option('--client', default='../target/release/encointer-client-notee',
               help='Client binary to communicate with the chain.')
-@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain.')
+@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain, or `gesell` alternatively.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
 @click.option('--idle-blocks', default=10, help='how many idle blocks to await before moving to next phase')
 def main(client, url, port, idle_blocks):

--- a/client/py_client/client.py
+++ b/client/py_client/client.py
@@ -114,6 +114,7 @@ class Client:
         return [self.new_account() for _ in range(0, amount)]
 
     def faucet(self, accounts, faucet_url='http://localhost:5000/api', is_faucet=False, pay_fees_in_cc=False):
+        print(f"connecting to faucet: {faucet_url}")
         if is_faucet:
             self.await_block(1)
             ret = self.run_cli_command(

--- a/client/py_client/helpers.py
+++ b/client/py_client/helpers.py
@@ -72,11 +72,7 @@ def generate_file_list(path_to_files):
 
 
 def set_local_or_remote_chain(client: str, port: str, node_url: str):
-    if node_url is None:
-        client = Client(rust_client=client, port=port)
+    if node_url == "gesell":
+        return Client(rust_client=client, node_url='wss://gesell.encointer.org', port=443)
     else:
-        if node_url == "gesell":
-            client = Client(rust_client=client, node_url='wss://gesell.encointer.org', port=443)
-        else:
-            client = Client(rust_client=client, node_url=node_url, port=port)
-    return client
+        return Client(rust_client=client, node_url=node_url, port=port)

--- a/client/py_client/helpers.py
+++ b/client/py_client/helpers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from .client import Client
 import warnings
 
+
 def purge_prompt(path: str, file_description: str):
     files = glob.glob(path + '/*')
     if files:
@@ -39,18 +40,18 @@ def mkdir_p(path):
 
 # this method takes the last content identifier, which is the one of the whole folder, for a file, there is only one cid so it works, too. 
 def take_only_last_cid(ret_cids):
-        # last line contains the directory cid
-        last = ret_cids.stdout.splitlines()[-1]
-        p = re.compile('Qm\\w*')
-        cids = p.findall(str(last))
-    
-        if cids:
-            print(cids[0])
-            return cids[0]
-        else:
-            warnings.warn('No cid returned. Something happened. stderr: ')
-            warnings.warn(str(ret_cids.stderr))
-            return ''
+    # last line contains the directory cid
+    last = ret_cids.stdout.splitlines()[-1]
+    p = re.compile('Qm\\w*')
+    cids = p.findall(str(last))
+
+    if cids:
+        print(cids[0])
+        return cids[0]
+    else:
+        warnings.warn('No cid returned. Something happened. stderr: ')
+        warnings.warn(str(ret_cids.stderr))
+        return ''
 
 
 def generate_file_list(path_to_files):
@@ -77,5 +78,5 @@ def set_local_or_remote_chain(client: str, port: str, node_url: str):
         if node_url == "gesell":
             client = Client(rust_client=client, node_url='wss://gesell.encointer.org', port=443)
         else:
-            raise Exception("You need to choose a valid remote chain")
+            client = Client(rust_client=client, node_url=node_url, port=port)
     return client

--- a/client/register-random-businesses-and-offerings.py
+++ b/client/register-random-businesses-and-offerings.py
@@ -3,7 +3,6 @@
 This is a test script that registers random businesses and offerings in a community which has been previously created with ./bot-community.py init
 """
 
-
 import glob
 import json
 import random
@@ -23,13 +22,15 @@ ICON_PATH = './test-data/assets/icons/community_icon.png'
 
 global IPFS_LOCAL
 
+
 @click.command()
-@click.option('--client', default='../target/release/encointer-client-notee', help='Client binary to communicate with the chain.')
+@click.option('--client', default='../target/release/encointer-client-notee',
+              help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
+@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain.')
 @click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used.')
-@click.option('-r', '--remote_chain', default=None, help='choose one of the remote chains: gesell.')
-def register_businesses_and_offerings(client, port, ipfs_local, remote_chain):
-    client = set_local_or_remote_chain(client, port, remote_chain)
+def register_businesses_and_offerings(client, port, ipfs_local, url):
+    client = set_local_or_remote_chain(client, port, url)
     global IPFS_LOCAL
     IPFS_LOCAL = ipfs_local
     owners = shop_owners()
@@ -83,6 +84,7 @@ def register_businesses_and_offerings(client, port, ipfs_local, remote_chain):
         print("registering offerings failed")
         exit(1)
     print(client.list_offerings_for_business(cid, owners[0]))
+
 
 def create_businesses(amount: int):
     """

--- a/client/register-random-businesses-and-offerings.py
+++ b/client/register-random-businesses-and-offerings.py
@@ -27,7 +27,7 @@ global IPFS_LOCAL
 @click.option('--client', default='../target/release/encointer-client-notee',
               help='Client binary to communicate with the chain.')
 @click.option('--port', default='9944', help='ws-port of the chain.')
-@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain.')
+@click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain, or `gesell` alternatively.')
 @click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used.')
 def register_businesses_and_offerings(client, port, ipfs_local, url):
     client = set_local_or_remote_chain(client, port, url)

--- a/scripts/docker/entryscript.sh
+++ b/scripts/docker/entryscript.sh
@@ -34,9 +34,10 @@ case $1 in
     /faucet.py --client /encointer-client-notee $PARAMS
     ;;
 
-  test-register-businesses)
-    /bot-community.py --client /encointer-client-notee $PARAMS init
-    /register-random-businesses-and-offerings.py --client /encointer-client-notee $PARAMS
+# not working yet, bot-commynity, and egister-random-businesses-and-offering have different interface. It is a pain.
+#  test-register-businesses)
+#    /bot-community.py --client /encointer-client-notee $PARAMS init
+#    /register-random-businesses-and-offerings.py --client /encointer-client-notee $PARAMS
     ;;
 
 # Does not work yet because the script wants the options like: cli.py --client <client> -u url -p port <cmd> <command params>

--- a/scripts/docker/entryscript.sh
+++ b/scripts/docker/entryscript.sh
@@ -14,16 +14,24 @@ case $1 in
     ;;
 
   bot-community-test)
+    # Example: note the port mapping, because we run the faucet at port 5000 in another container ...
+    # docker run -it -p 5005:5000 --add-host host.docker.internal:host-gateway test-client bot-community-test -r ws://host.docker.internal --port 9944 -f http://host.docker.internal:5000/api
+
+    # currently broken, for some reason it can't connect to the faucet
     /bot-community.py --client /encointer-client-notee $PARAMS init
 #    /bot-community.py --client /encointer-client-notee $PARAMS test
 #    diff bot-stats.csv bot-stats-golden.csv
     ;;
 
   phase.py)
+    # Example: note the port mapping, because we run another the faucet exposing 5000
+    # docker run -it -p 5001:5000 --add-host host.docker.internal:host-gateway test-client phase.py -r ws://host.docker.internal --port 9944 --idle-blocks 3
     /phase.py --client /encointer-client-notee $PARAMS
     ;;
 
   faucet.py)
+    # Example:
+    # docker run -it --add-host host.docker.internal:host-gateway test-client faucet.py -u ws://host.docker.internal --port 9944
     /faucet.py --client /encointer-client-notee $PARAMS
     ;;
 

--- a/scripts/docker/entryscript.sh
+++ b/scripts/docker/entryscript.sh
@@ -13,14 +13,10 @@ case $1 in
     /bootstrap_demo_community.py --client /encointer-client-notee $PARAMS
     ;;
 
-  bot-community.py)
-    /bot-community.py --client /encointer-client-notee $PARAMS
-    ;;
-
-  check-bot-stats)
-    # Stats should be the string from "$(cat client/bot-stats.csv)"
-    $STATS > bot-stats.csv
-    diff bot-stats.csv bot-stats-golden.csv
+  bot-community-test)
+    /bot-community.py --client /encointer-client-notee $PARAMS init
+#    /bot-community.py --client /encointer-client-notee $PARAMS test
+#    diff bot-stats.csv bot-stats-golden.csv
     ;;
 
   phase.py)
@@ -29,6 +25,11 @@ case $1 in
 
   faucet.py)
     /faucet.py --client /encointer-client-notee $PARAMS
+    ;;
+
+  test-register-businesses)
+    /bot-community.py --client /encointer-client-notee $PARAMS init
+    /register-random-businesses-and-offerings.py --client /encointer-client-notee $PARAMS
     ;;
 
 # Does not work yet because the script wants the options like: cli.py --client <client> -u url -p port <cmd> <command params>

--- a/scripts/docker/entryscript.sh
+++ b/scripts/docker/entryscript.sh
@@ -21,6 +21,10 @@ case $1 in
     /phase.py --client /encointer-client-notee $PARAMS
     ;;
 
+  faucet.py)
+    /faucet.py --client /encointer-client-notee $PARAMS
+    ;;
+
 # Does not work yet because the script wants the options like: cli.py --client <client> -u url -p port <cmd> <command params>
 #  cli.py)
 #    /cli.py $PARAMS

--- a/scripts/docker/entryscript.sh
+++ b/scripts/docker/entryscript.sh
@@ -14,8 +14,8 @@ case $1 in
     ;;
 
   bot-community-test)
-    # Example: note the port mapping, because we run the faucet at port 5000 in another container ...
-    # docker run -it -p 5005:5000 --add-host host.docker.internal:host-gateway test-client bot-community-test -r ws://host.docker.internal --port 9944 -f http://host.docker.internal:5000/api
+    # Example:
+    # docker run -it --add-host host.docker.internal:host-gateway test-client bot-community-test -u ws://host.docker.internal --port 9944 -f http://host.docker.internal:5000/api
 
     /bot-community.py --client /encointer-client-notee $PARAMS init
     /bot-community.py --client /encointer-client-notee $PARAMS test
@@ -23,26 +23,21 @@ case $1 in
     ;;
 
   phase.py)
-    # Example: note the port mapping, because we run another the faucet exposing 5000
-    # docker run -it -p 5001:5000 --add-host host.docker.internal:host-gateway test-client phase.py -r ws://host.docker.internal --port 9944 --idle-blocks 3
+    # Example:
+    # docker run -it --add-host host.docker.internal:host-gateway test-client phase.py -u ws://host.docker.internal --port 9944 --idle-blocks 3
     /phase.py --client /encointer-client-notee $PARAMS
     ;;
 
   faucet.py)
-    # Example:
+    # Example: Note: we have to expose the port
     # docker run -it -p 5000:5000 --add-host host.docker.internal:host-gateway test-client faucet.py -u ws://host.docker.internal --port 9944
     /faucet.py --client /encointer-client-notee $PARAMS
     ;;
 
-# not working yet, bot-commynity, and egister-random-businesses-and-offering have different interface. It is a pain.
+# Todo #386: Not working yet; bot-community, and register-random-businesses-and-offering have different interface.
 #  test-register-businesses)
 #    /bot-community.py --client /encointer-client-notee $PARAMS init
 #    /register-random-businesses-and-offerings.py --client /encointer-client-notee $PARAMS
-#    ;;
-
-# Does not work yet because the script wants the options like: cli.py --client <client> -u url -p port <cmd> <command params>
-#  cli.py)
-#    /cli.py $PARAMS
 #    ;;
 
   *)

--- a/scripts/docker/entryscript.sh
+++ b/scripts/docker/entryscript.sh
@@ -17,6 +17,12 @@ case $1 in
     /bot-community.py --client /encointer-client-notee $PARAMS
     ;;
 
+  check-bot-stats)
+    # Stats should be the string from "$(cat client/bot-stats.csv)"
+    $STATS > bot-stats.csv
+    diff bot-stats.csv bot-stats-golden.csv
+    ;;
+
   phase.py)
     /phase.py --client /encointer-client-notee $PARAMS
     ;;

--- a/scripts/docker/entryscript.sh
+++ b/scripts/docker/entryscript.sh
@@ -38,7 +38,7 @@ case $1 in
 #  test-register-businesses)
 #    /bot-community.py --client /encointer-client-notee $PARAMS init
 #    /register-random-businesses-and-offerings.py --client /encointer-client-notee $PARAMS
-    ;;
+#    ;;
 
 # Does not work yet because the script wants the options like: cli.py --client <client> -u url -p port <cmd> <command params>
 #  cli.py)

--- a/scripts/docker/entryscript.sh
+++ b/scripts/docker/entryscript.sh
@@ -19,8 +19,8 @@ case $1 in
 
     # currently broken, for some reason it can't connect to the faucet
     /bot-community.py --client /encointer-client-notee $PARAMS init
-#    /bot-community.py --client /encointer-client-notee $PARAMS test
-#    diff bot-stats.csv bot-stats-golden.csv
+    /bot-community.py --client /encointer-client-notee $PARAMS test
+    diff bot-stats.csv bot-stats-golden.csv
     ;;
 
   phase.py)
@@ -31,7 +31,7 @@ case $1 in
 
   faucet.py)
     # Example:
-    # docker run -it --add-host host.docker.internal:host-gateway test-client faucet.py -u ws://host.docker.internal --port 9944
+    # docker run -it -p 5000:5000 --add-host host.docker.internal:host-gateway test-client faucet.py -u ws://host.docker.internal --port 9944
     /faucet.py --client /encointer-client-notee $PARAMS
     ;;
 

--- a/scripts/docker/entryscript.sh
+++ b/scripts/docker/entryscript.sh
@@ -13,6 +13,14 @@ case $1 in
     /bootstrap_demo_community.py --client /encointer-client-notee $PARAMS
     ;;
 
+  bot-community.py)
+    /bot-community.py --client /encointer-client-notee $PARAMS
+    ;;
+
+  phase.py)
+    /phase.py --client /encointer-client-notee $PARAMS
+    ;;
+
 # Does not work yet because the script wants the options like: cli.py --client <client> -u url -p port <cmd> <command params>
 #  cli.py)
 #    /cli.py $PARAMS

--- a/scripts/docker/entryscript.sh
+++ b/scripts/docker/entryscript.sh
@@ -17,7 +17,6 @@ case $1 in
     # Example: note the port mapping, because we run the faucet at port 5000 in another container ...
     # docker run -it -p 5005:5000 --add-host host.docker.internal:host-gateway test-client bot-community-test -r ws://host.docker.internal --port 9944 -f http://host.docker.internal:5000/api
 
-    # currently broken, for some reason it can't connect to the faucet
     /bot-community.py --client /encointer-client-notee $PARAMS init
     /bot-community.py --client /encointer-client-notee $PARAMS test
     diff bot-stats.csv bot-stats-golden.csv


### PR DESCRIPTION
In essence this introduces the feature to run the bot-community, phase.py and faucet.py from the enconter-client docker container. To achieve that, a few minor changes were necessary:

* The `phase.py` CLI has had minor adjustements to be able to run from within a docker container
* The `faucet.py` now takes some arguments and exposes `0.0.0.0` instead of localhost to be reachable from outside the docker
* Breaking: unify the CLI for our scripts in general such that there is only `-u` as a url argument. `-r` has been removed.

Tests:
* The CI does now also run the bootstrap and the bot-community integration tests in docker to ensure that the docker works.

Future work:
* Registering businesses does not work yet, tracking issue: #386