### PR TITLE
Client updates to fix bootstrapping and bot-community script for parachain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,8 +300,8 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          - bootstrap_demo_community.py --signer //Bob --test
-          - bot-community-test -f http://host.docker.internal:5000/api
+          - bootstrap_demo_community.py --signer //Bob --call-wrapping sudo --test
+          - bot-community-test -f --call-wrapping sudo http://host.docker.internal:5000/api
           # Todo: #386
           # - test-register-businesses -f http://host.docker.internal:5000/api
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,8 +300,8 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          - bootstrap_demo_community.py --signer //Bob --call-wrapping sudo --test
-          - bot-community-test -f --call-wrapping sudo http://host.docker.internal:5000/api
+          - bootstrap_demo_community.py --signer //Bob --wrap-call sudo --test
+          - bot-community-test -f --wrap-call sudo http://host.docker.internal:5000/api
           # Todo: #386
           # - test-register-businesses -f http://host.docker.internal:5000/api
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,8 +300,8 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          - bootstrap_demo_community.py --signer //Bob --wrap-call sudo --test
-          - bot-community-test -f --wrap-call sudo http://host.docker.internal:5000/api
+          - bootstrap_demo_community.py --signer //Bob --test
+          - bot-community-test -f http://host.docker.internal:5000/api
           # Todo: #386
           # - test-register-businesses -f http://host.docker.internal:5000/api
     steps:

--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -67,9 +67,9 @@ def update_spec_with_cid(file, cid):
         spec_json.truncate()
 
 
-def create_community(client, spec_file_path, ipfs_local, signer, wrap_call="none"):
+def create_community(client, spec_file_path, ipfs_local, signer, wrap_call="none", batch_size=100):
     # non sudoer can create community on gesell (provide --signer but don't use //Alice), but not on parachain (where council will create)
-    cid = client.new_community(spec_file_path, signer=signer, wrap_call=wrap_call)
+    cid = client.new_community(spec_file_path, signer=signer, wrap_call=wrap_call, batch_size=batch_size)
     if len(cid) > 10:
         print(f'👬 Registered community with cid: {cid}')
     else:
@@ -412,9 +412,10 @@ def test_democracy(client, cid):
               help='Specify community spec-file to be registered.')
 @click.option('-t', '--test', is_flag=True, help='if set, run integration tests.')
 @click.option('-w', '--wrap-call', default="none", help='wrap the call, values: none|sudo|collective')
-def main(ipfs_local, client, signer, url, port, spec_file, test, wrap_call):
+@click.option('-b', '--batch-size', default=100, help='batch size of the addLocation call (parachain is limited to 15)')
+def main(ipfs_local, client, signer, url, port, spec_file, test, wrap_call, batch_size):
     client = Client(rust_client=client, node_url=url, port=port)
-    cid = create_community(client, spec_file, ipfs_local, signer, wrap_call=wrap_call)
+    cid = create_community(client, spec_file, ipfs_local, signer, wrap_call=wrap_call, batch_size=batch_size)
 
     newbie = client.create_accounts(1)[0]
     faucet(client, cid, [account3, newbie])

--- a/client/bootstrap_demo_community.py
+++ b/client/bootstrap_demo_community.py
@@ -67,9 +67,9 @@ def update_spec_with_cid(file, cid):
         spec_json.truncate()
 
 
-def create_community(client, spec_file_path, ipfs_local, signer):
+def create_community(client, spec_file_path, ipfs_local, signer, wrap_call="none"):
     # non sudoer can create community on gesell (provide --signer but don't use //Alice), but not on parachain (where council will create)
-    cid = client.new_community(spec_file_path, signer=signer)
+    cid = client.new_community(spec_file_path, signer=signer, wrap_call=wrap_call)
     if len(cid) > 10:
         print(f'👬 Registered community with cid: {cid}')
     else:
@@ -411,9 +411,10 @@ def test_democracy(client, cid):
 @click.option('-s', '--spec-file', default=f'{TEST_DATA_DIR}{TEST_LOCATIONS_MEDITERRANEAN}',
               help='Specify community spec-file to be registered.')
 @click.option('-t', '--test', is_flag=True, help='if set, run integration tests.')
-def main(ipfs_local, client, signer, url, port, spec_file, test):
+@click.option('-w', '--wrap-call', default="none", help='wrap the call, values: none|sudo|collective')
+def main(ipfs_local, client, signer, url, port, spec_file, test, wrap_call):
     client = Client(rust_client=client, node_url=url, port=port)
-    cid = create_community(client, spec_file, ipfs_local, signer)
+    cid = create_community(client, spec_file, ipfs_local, signer, wrap_call=wrap_call)
 
     newbie = client.create_accounts(1)[0]
     faucet(client, cid, [account3, newbie])

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -54,6 +54,7 @@ NUMBER_OF_ENDORSEMENTS_PER_REGISTRATION = 10
 @click.option('-f', '--faucet_url', default='http://localhost:5000/api',
               help='url for the faucet (only needed for test/benchmark cmd)')
 @click.option('-w', '--wrap-call', default="none", help='wrap the call, values: none|sudo|collective')
+# interestingly, the error can be misleading, it can be: 1. TX would exhaust block limits, 2. invalid collective propose weight
 @click.option('-b', '--batch-size', default=100, help='batch size of the addLocation call (parachain is limited to 7 (maybe a bit more))')
 @click.option('-n', '--number-of-locations', default=100, help='number of locations to generate for the bot-community')
 @click.pass_context

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -48,7 +48,7 @@ NUMBER_OF_ENDORSEMENTS_PER_REGISTRATION = 10
 @click.group()
 @click.option('--client', default='../target/release/encointer-client-notee',
               help='Client binary to communicate with the chain.')
-@click.option('--port', default='9944', help='ws-port of the chain.')
+@click.option('-p', '--port', default='9944', help='ws-port of the chain.')
 @click.option('-u', '--url', default='ws://127.0.0.1', help='URL of the chain, or `gesell` alternatively.')
 @click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used.')
 @click.option('-f', '--faucet_url', default='http://localhost:5000/api',

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -56,8 +56,9 @@ NUMBER_OF_ENDORSEMENTS_PER_REGISTRATION = 10
 @click.option('-f', '--faucet_url', default='http://localhost:5000/api',
               help='url for the faucet (only needed for test/benchmark cmd)')
 @click.option('-w', '--wrap-call', default="none", help='wrap the call, values: none|sudo|collective')
+@click.option('-b', '--batch-size', default=100, help='batch size of the addLocation call (parachain is limited to 15)')
 @click.pass_context
-def cli(ctx, client, port, ipfs_local, url, faucet_url, wrap_call):
+def cli(ctx, client, port, ipfs_local, url, faucet_url, wrap_call, batch_size):
     ctx.ensure_object(dict)
     cl = set_local_or_remote_chain(client, port, url)
     ctx.obj['client'] = cl
@@ -66,6 +67,7 @@ def cli(ctx, client, port, ipfs_local, url, faucet_url, wrap_call):
     ctx.obj['url'] = url
     ctx.obj['faucet_url'] = faucet_url
     ctx.obj['wrap_call'] = wrap_call
+    ctx.obj['batch_size'] = batch_size
 
 
 @cli.command()
@@ -74,6 +76,7 @@ def init(ctx):
     client = ctx['client']
     faucet_url = ctx['faucet_url']
     wrap_call = ctx['wrap_call']
+    batch_size = ctx['batch_size']
     purge_keystore_prompt()
 
     root_dir = os.path.realpath(ASSETS_PATH)
@@ -95,7 +98,7 @@ def init(ctx):
         print(f"waiting for ceremony phase Registering. now is {phase}")
         client.await_block()
 
-    cid = client.new_community(specfile, signer='//Alice', wrap_call=wrap_call)
+    cid = client.new_community(specfile, signer='//Alice', wrap_call=wrap_call, batch_size=batch_size)
     print(f'created community with cid: {cid}')
     write_cid(cid)
     client.await_block()

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -55,8 +55,9 @@ NUMBER_OF_ENDORSEMENTS_PER_REGISTRATION = 10
 @click.option('-l', '--ipfs_local', is_flag=True, help='if set, local ipfs node is used.')
 @click.option('-f', '--faucet_url', default='http://localhost:5000/api',
               help='url for the faucet (only needed for test/benchmark cmd)')
+@click.option('-w', '--wrap-call', default="none", help='wrap the call, values: none|sudo|collective')
 @click.pass_context
-def cli(ctx, client, port, ipfs_local, url, faucet_url):
+def cli(ctx, client, port, ipfs_local, url, faucet_url, wrap_call):
     ctx.ensure_object(dict)
     cl = set_local_or_remote_chain(client, port, url)
     ctx.obj['client'] = cl
@@ -64,6 +65,7 @@ def cli(ctx, client, port, ipfs_local, url, faucet_url):
     ctx.obj['ipfs_local'] = ipfs_local
     ctx.obj['url'] = url
     ctx.obj['faucet_url'] = faucet_url
+    ctx.obj['wrap_call'] = wrap_call
 
 
 @cli.command()
@@ -71,6 +73,7 @@ def cli(ctx, client, port, ipfs_local, url, faucet_url):
 def init(ctx):
     client = ctx['client']
     faucet_url = ctx['faucet_url']
+    wrap_call = ctx['wrap_call']
     purge_keystore_prompt()
 
     root_dir = os.path.realpath(ASSETS_PATH)
@@ -92,7 +95,7 @@ def init(ctx):
         print(f"waiting for ceremony phase Registering. now is {phase}")
         client.await_block()
 
-    cid = client.new_community(specfile, signer='//Alice')
+    cid = client.new_community(specfile, signer='//Alice', wrap_call=wrap_call)
     print(f'created community with cid: {cid}')
     write_cid(cid)
     client.await_block()

--- a/client/bot-community.py
+++ b/client/bot-community.py
@@ -42,8 +42,6 @@ from py_client.client import Client, ExtrinsicFeePaymentImpossible, ExtrinsicWro
 from py_client.ipfs import Ipfs, ASSETS_PATH
 
 KEYSTORE_PATH = './my_keystore'
-NUMBER_OF_LOCATIONS = 100
-MAX_POPULATION = 10 * NUMBER_OF_LOCATIONS
 NUMBER_OF_ENDORSEMENTS_PER_REGISTRATION = 10
 
 
@@ -56,9 +54,10 @@ NUMBER_OF_ENDORSEMENTS_PER_REGISTRATION = 10
 @click.option('-f', '--faucet_url', default='http://localhost:5000/api',
               help='url for the faucet (only needed for test/benchmark cmd)')
 @click.option('-w', '--wrap-call', default="none", help='wrap the call, values: none|sudo|collective')
-@click.option('-b', '--batch-size', default=100, help='batch size of the addLocation call (parachain is limited to 15)')
+@click.option('-b', '--batch-size', default=100, help='batch size of the addLocation call (parachain is limited to 7 (maybe a bit more))')
+@click.option('-n', '--number-of-locations', default=100, help='number of locations to generate for the bot-community')
 @click.pass_context
-def cli(ctx, client, port, ipfs_local, url, faucet_url, wrap_call, batch_size):
+def cli(ctx, client, port, ipfs_local, url, faucet_url, wrap_call, batch_size, number_of_locations):
     ctx.ensure_object(dict)
     cl = set_local_or_remote_chain(client, port, url)
     ctx.obj['client'] = cl
@@ -68,6 +67,8 @@ def cli(ctx, client, port, ipfs_local, url, faucet_url, wrap_call, batch_size):
     ctx.obj['faucet_url'] = faucet_url
     ctx.obj['wrap_call'] = wrap_call
     ctx.obj['batch_size'] = batch_size
+    ctx.obj['number_of_locations'] = number_of_locations
+    ctx.obj['max_population'] = number_of_locations * 10
 
 
 @cli.command()
@@ -77,6 +78,7 @@ def init(ctx):
     faucet_url = ctx['faucet_url']
     wrap_call = ctx['wrap_call']
     batch_size = ctx['batch_size']
+    number_of_locations = ctx['number_of_locations']
     purge_keystore_prompt()
 
     root_dir = os.path.realpath(ASSETS_PATH)
@@ -88,7 +90,7 @@ def init(ctx):
     print('initializing community')
     b = init_bootstrappers(client, faucet_url)
     client.await_block()
-    specfile = random_community_spec(b, ipfs_cid, NUMBER_OF_LOCATIONS)
+    specfile = random_community_spec(b, ipfs_cid, number_of_locations)
     print(f'generated community spec: {specfile} first bootstrapper {b[0]}')
 
     while True:
@@ -113,12 +115,13 @@ def purge_communities():
 @cli.command()
 @click.pass_obj
 def execute_current_phase(ctx):
-    return _execute_current_phase(ctx['client'], ctx['faucet_url'])
+    return _execute_current_phase(ctx, ctx['client'], ctx['faucet_url'])
 
 
-def _execute_current_phase(client: Client, faucet_url: str):
+def _execute_current_phase(ctx, client: Client, faucet_url: str):
     client = client
     cid = read_cid()
+    max_population = ctx["max_population"]
     phase = client.get_phase()
     cindex = client.get_cindex()
     print(f'🕑 phase is {phase} and ceremony index is {cindex}')
@@ -134,7 +137,7 @@ def _execute_current_phase(client: Client, faucet_url: str):
 
         total_supply = write_current_stats(client, accounts, cid)
         if total_supply > 0:
-            init_new_community_members(client, cid, len(accounts), faucet_url=faucet_url)
+            init_new_community_members(client, cid, len(accounts), faucet_url=faucet_url, max_population=max_population)
 
         # updated account list with new community members
         accounts = client.list_accounts()
@@ -166,7 +169,7 @@ def benchmark(ctx):
     faucet_url = ctx['faucet_url']
     print('will grow population forever')
     while True:
-        phase = _execute_current_phase(py_client, faucet_url=faucet_url)
+        phase = _execute_current_phase(ctx, py_client, faucet_url=faucet_url)
         while phase == py_client.get_phase():
             print("awaiting next phase...")
             py_client.await_block()
@@ -179,7 +182,7 @@ def test(ctx):
     faucet_url = ctx['faucet_url']
     print('will grow population for fixed number of ceremonies')
     for i in range(3 * 2 + 1):
-        phase = _execute_current_phase(py_client, faucet_url=faucet_url)
+        phase = _execute_current_phase(ctx, py_client, faucet_url=faucet_url)
         while phase == py_client.get_phase():
             print("awaiting next phase...")
             py_client.await_block()
@@ -253,11 +256,11 @@ def endorse_new_accounts(client: Client, cid: str, bootstrappers_and_tickets, en
     return endorsees
 
 
-def get_newbie_amount(current_population: int):
+def get_newbie_amount(current_population: int, max_population: int):
     return min(
         # register more than can participate, to test restrictions
         floor(current_population / 1.5),
-        MAX_POPULATION - current_population
+        max_population - current_population
     )
 
 
@@ -276,7 +279,8 @@ def init_new_community_members(
         client: Client,
         cid: str,
         current_community_size: int,
-        faucet_url: str
+        faucet_url: str,
+        max_population: int
 ):
     """ Initializes new community members based on the `current_community_size` and the amount of endorsements we can
         perform.
@@ -296,7 +300,7 @@ def init_new_community_members(
         client.await_block()
         print(f'Added endorsees to community: {len(endorsees)}')
 
-    newbies = client.create_accounts(get_newbie_amount(current_community_size + len(endorsees)))
+    newbies = client.create_accounts(get_newbie_amount(current_community_size + len(endorsees), max_population))
 
     print(f'Add newbies to community {len(newbies)}')
 

--- a/client/phase.py
+++ b/client/phase.py
@@ -52,10 +52,10 @@ def main(client, url, port, idle_blocks):
 def subscription_handler(event_count, update_nr, subscription_id):
     global COUNT, patience
     print(f'events: {event_count}, idle blocks {COUNT}')
-    if COUNT > patience:
-        return update_nr
-    elif event_count.value <= INTRINSIC_EVENTS:
+    if event_count.value <= INTRINSIC_EVENTS:
         COUNT += 1
+        if COUNT > patience:
+            return update_nr
     else:
         COUNT = 0
 

--- a/client/phase.py
+++ b/client/phase.py
@@ -17,8 +17,9 @@ from py_client.helpers import set_local_or_remote_chain
 global COUNT
 COUNT = 0
 
-# a solochain has timestamp.set event in every block, a parachain additionaly has parachainSystem.setValidationData
-INTRINSIC_EVENTS = 2
+# a solochain has timestamp.set event in every block, a parachain additionaly has parachainSystem.setValidationData and
+# a balance transfer for the collator rewards.
+INTRINSIC_EVENTS = 3
 
 global patience
 

--- a/client/py_client/client.py
+++ b/client/py_client/client.py
@@ -143,12 +143,12 @@ class Client:
                 (cindex, cid, rep.strip().split('::')[1]))
         return reputation_history
 
-    def new_community(self, specfile, signer=None, wrap_call="none", pay_fees_in_cc=False):
+    def new_community(self, specfile, signer=None, wrap_call="none", batch_size=100, pay_fees_in_cc=False):
         cmd = ["new-community", specfile]
         if signer:
             cmd += ["--signer", signer]
 
-        cmd += ["--wrap-call", wrap_call]
+        cmd += ["--wrap-call", wrap_call, "--batch-size", str(batch_size)]
         ret = self.run_cli_command(cmd, pay_fees_in_cc=pay_fees_in_cc)
         ensure_clean_exit(ret)
         return ret.stdout.decode("utf-8").strip()

--- a/client/py_client/client.py
+++ b/client/py_client/client.py
@@ -143,10 +143,12 @@ class Client:
                 (cindex, cid, rep.strip().split('::')[1]))
         return reputation_history
 
-    def new_community(self, specfile, signer=None, pay_fees_in_cc=False):
+    def new_community(self, specfile, signer=None, wrap_call="none", pay_fees_in_cc=False):
         cmd = ["new-community", specfile]
         if signer:
             cmd += ["--signer", signer]
+
+        cmd += ["--wrap-call", wrap_call]
         ret = self.run_cli_command(cmd, pay_fees_in_cc=pay_fees_in_cc)
         ensure_clean_exit(ret)
         return ret.stdout.decode("utf-8").strip()

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -38,6 +38,7 @@ const NOMINAL_INCOME_ARG: &str = "nominal-income";
 const DEMURRAGE_HALVING_BLOCKS_ARG: &str = "demurage-halving-blocks";
 const PURPOSE_ID_ARG: &str = "purpose-id";
 const WRAP_CALL_ARG: &str = "wrap-call";
+const BATCH_SIZE_ARG: &str = "batch-size";
 
 pub trait EncointerArgs<'b> {
 	fn account_arg(self) -> Self;
@@ -76,7 +77,8 @@ pub trait EncointerArgs<'b> {
 	fn nominal_income_arg(self) -> Self;
 	fn demurrage_halving_blocks_arg(self) -> Self;
 	fn purpose_id_arg(self) -> Self;
-	fn wrap_call(self) -> Self;
+	fn wrap_call_arg(self) -> Self;
+	fn batch_size_arg(self) -> Self;
 }
 
 pub trait EncointerArgsExtractor {
@@ -115,7 +117,8 @@ pub trait EncointerArgsExtractor {
 	fn nominal_income_arg(&self) -> Option<BalanceType>;
 	fn demurrage_halving_blocks_arg(&self) -> Option<u64>;
 	fn purpose_id_arg(&self) -> Option<PurposeIdType>;
-	fn wrap_call(&self) -> CallWrapping;
+	fn wrap_call_arg(&self) -> CallWrapping;
+	fn batch_size_arg(&self) -> u32;
 }
 
 impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
@@ -461,7 +464,7 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 		)
 	}
 
-	fn wrap_call(self) -> Self {
+	fn wrap_call_arg(self) -> Self {
         self.arg(
 			Arg::with_name(WRAP_CALL_ARG)
 				.short("w")
@@ -472,6 +475,19 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 				.value_name("none|sudo|collective")
 				.help("If the transaction should be wrapped with a sudo/collective call or not."),
         )
+	}
+
+	fn batch_size_arg(self) -> Self {
+		self.arg(
+			Arg::with_name(BATCH_SIZE_ARG)
+				.short("b")
+				.long("batch-size")
+				.takes_value(true)
+				.required(false)
+				.default_value("100")
+				.value_name("u32")
+				.help("Maximum batch size"),
+		)
 	}
 }
 
@@ -601,8 +617,12 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 		self.value_of(PURPOSE_ID_ARG).map(|v| v.parse().unwrap())
 	}
 
-    fn wrap_call(&self) -> CallWrapping {
+    fn wrap_call_arg(&self) -> CallWrapping {
         self.value_of(WRAP_CALL_ARG).map(|v| v.parse().unwrap()).unwrap_or(CallWrapping::None)
 
     }
+
+	fn batch_size_arg(&self) -> u32 {
+		self.value_of(BATCH_SIZE_ARG).map(|v| v.parse().unwrap()).unwrap_or(100)
+	}
 }

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -37,7 +37,6 @@ const INACTIVITY_TIMEOUT_ARG: &str = "inactivity-timeout";
 const NOMINAL_INCOME_ARG: &str = "nominal-income";
 const DEMURRAGE_HALVING_BLOCKS_ARG: &str = "demurage-halving-blocks";
 const PURPOSE_ID_ARG: &str = "purpose-id";
-const SHOULD_SEND_TX_ARG: &str = "should-send-tx";
 const WRAP_CALL_ARG: &str = "wrap-call";
 
 pub trait EncointerArgs<'b> {
@@ -77,7 +76,6 @@ pub trait EncointerArgs<'b> {
 	fn nominal_income_arg(self) -> Self;
 	fn demurrage_halving_blocks_arg(self) -> Self;
 	fn purpose_id_arg(self) -> Self;
-	fn should_send_tx(self) -> Self;
 	fn wrap_call(self) -> Self;
 }
 
@@ -117,7 +115,6 @@ pub trait EncointerArgsExtractor {
 	fn nominal_income_arg(&self) -> Option<BalanceType>;
 	fn demurrage_halving_blocks_arg(&self) -> Option<u64>;
 	fn purpose_id_arg(&self) -> Option<PurposeIdType>;
-	fn should_send_tx(&self) -> bool;
 	fn wrap_call(&self) -> CallWrapping;
 }
 
@@ -464,25 +461,16 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 		)
 	}
 
-	fn should_send_tx(self) -> Self {
-		self.arg(
-			Arg::with_name(SHOULD_SEND_TX_ARG)
-				.takes_value(false)
-				.required(false)
-				.default_value("true")
-				.value_name("SHOULD_SEND_TX")
-				.help("If the transaction should be sent"),
-		)
-	}
-
 	fn wrap_call(self) -> Self {
         self.arg(
-            Arg::with_name(WRAP_CALL_ARG)
-                .takes_value(true)
-                .required(false)
-                .default_value("none")
-                .value_name("")
-                .help("If the transaction should be wrapped with a sudo/collective call or not."),
+			Arg::with_name(WRAP_CALL_ARG)
+				.short("w")
+				.long("wrap-call")
+				.takes_value(true)
+				.required(false)
+				.default_value("none")
+				.value_name("none|sudo|collective")
+				.help("If the transaction should be wrapped with a sudo/collective call or not."),
         )
 	}
 }
@@ -612,10 +600,6 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 	fn purpose_id_arg(&self) -> Option<PurposeIdType> {
 		self.value_of(PURPOSE_ID_ARG).map(|v| v.parse().unwrap())
 	}
-
-    fn should_send_tx(&self) -> bool {
-        self.value_of(SHOULD_SEND_TX_ARG).map(|v| v.parse().unwrap()).unwrap_or(true)
-    }
 
     fn wrap_call(&self) -> CallWrapping {
         self.value_of(WRAP_CALL_ARG).map(|v| v.parse().unwrap()).unwrap_or(CallWrapping::None)

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -465,7 +465,7 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 	}
 
 	fn wrap_call_arg(self) -> Self {
-        self.arg(
+		self.arg(
 			Arg::with_name(WRAP_CALL_ARG)
 				.short("w")
 				.long("wrap-call")
@@ -474,7 +474,7 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 				.default_value("none")
 				.value_name("none|sudo|collective")
 				.help("If the transaction should be wrapped with a sudo/collective call or not."),
-        )
+		)
 	}
 
 	fn batch_size_arg(self) -> Self {
@@ -617,10 +617,11 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 		self.value_of(PURPOSE_ID_ARG).map(|v| v.parse().unwrap())
 	}
 
-    fn wrap_call_arg(&self) -> CallWrapping {
-        self.value_of(WRAP_CALL_ARG).map(|v| v.parse().unwrap()).unwrap_or(CallWrapping::None)
-
-    }
+	fn wrap_call_arg(&self) -> CallWrapping {
+		self.value_of(WRAP_CALL_ARG)
+			.map(|v| v.parse().unwrap())
+			.unwrap_or(CallWrapping::None)
+	}
 
 	fn batch_size_arg(&self) -> u32 {
 		self.value_of(BATCH_SIZE_ARG).map(|v| v.parse().unwrap()).unwrap_or(100)

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -1,3 +1,4 @@
+use crate::utils::CallWrapping;
 use clap::{App, Arg, ArgMatches};
 use encointer_primitives::{balances::BalanceType, reputation_commitments::PurposeIdType};
 use sp_core::{bytes, H256 as Hash};
@@ -36,6 +37,8 @@ const INACTIVITY_TIMEOUT_ARG: &str = "inactivity-timeout";
 const NOMINAL_INCOME_ARG: &str = "nominal-income";
 const DEMURRAGE_HALVING_BLOCKS_ARG: &str = "demurage-halving-blocks";
 const PURPOSE_ID_ARG: &str = "purpose-id";
+const SHOULD_SEND_TX_ARG: &str = "should-send-tx";
+const WRAP_CALL_ARG: &str = "wrap-call";
 
 pub trait EncointerArgs<'b> {
 	fn account_arg(self) -> Self;
@@ -74,6 +77,8 @@ pub trait EncointerArgs<'b> {
 	fn nominal_income_arg(self) -> Self;
 	fn demurrage_halving_blocks_arg(self) -> Self;
 	fn purpose_id_arg(self) -> Self;
+	fn should_send_tx(self) -> Self;
+	fn wrap_call(self) -> Self;
 }
 
 pub trait EncointerArgsExtractor {
@@ -112,6 +117,8 @@ pub trait EncointerArgsExtractor {
 	fn nominal_income_arg(&self) -> Option<BalanceType>;
 	fn demurrage_halving_blocks_arg(&self) -> Option<u64>;
 	fn purpose_id_arg(&self) -> Option<PurposeIdType>;
+	fn should_send_tx(&self) -> bool;
+	fn wrap_call(&self) -> CallWrapping;
 }
 
 impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
@@ -456,6 +463,28 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 				.help("reputation commitment purpose id"),
 		)
 	}
+
+	fn should_send_tx(self) -> Self {
+		self.arg(
+			Arg::with_name(SHOULD_SEND_TX_ARG)
+				.takes_value(false)
+				.required(false)
+				.default_value("true")
+				.value_name("SHOULD_SEND_TX")
+				.help("If the transaction should be sent"),
+		)
+	}
+
+	fn wrap_call(self) -> Self {
+        self.arg(
+            Arg::with_name(WRAP_CALL_ARG)
+                .takes_value(false)
+                .required(false)
+                .default_value("none")
+                .value_name("")
+                .help("If the transaction should be wrapped with a sudo/collective call or not."),
+        )
+	}
 }
 
 impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
@@ -583,4 +612,13 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 	fn purpose_id_arg(&self) -> Option<PurposeIdType> {
 		self.value_of(PURPOSE_ID_ARG).map(|v| v.parse().unwrap())
 	}
+
+    fn should_send_tx(&self) -> bool {
+        self.value_of(SHOULD_SEND_TX_ARG).map(|v| v.parse().unwrap()).unwrap_or(true)
+    }
+
+    fn wrap_call(&self) -> CallWrapping {
+        self.value_of(WRAP_CALL_ARG).map(|v| v.parse().unwrap()).unwrap_or(CallWrapping::None)
+
+    }
 }

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -478,7 +478,7 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 	fn wrap_call(self) -> Self {
         self.arg(
             Arg::with_name(WRAP_CALL_ARG)
-                .takes_value(false)
+                .takes_value(true)
                 .required(false)
                 .default_value("none")
                 .value_name("")

--- a/client/src/commands/encointer_communities.rs
+++ b/client/src/commands/encointer_communities.rs
@@ -1,20 +1,23 @@
 use crate::{
-    cli_args::EncointerArgsExtractor,
-    community_spec::{
-        add_location_call, new_community_call, read_community_spec_from_file, AddLocationCall,
-        CommunitySpec,
-    },
-    exit_code,
-    utils::{
-        batch_call, collective_propose_call, contains_sudo_pallet, get_chain_api, get_councillors,
-        keys::get_pair_from_str, print_raw_call, send_and_wait_for_in_block, sudo_call, xt,
-        OpaqueCall,
-    },
+	cli_args::EncointerArgsExtractor,
+	community_spec::{
+		add_location_call, new_community_call, read_community_spec_from_file, AddLocationCall,
+		CommunitySpec,
+	},
+	exit_code,
+	utils::{
+		batch_call, collective_propose_call, contains_sudo_pallet, get_chain_api, get_councillors,
+		keys::get_pair_from_str, print_raw_call, send_and_wait_for_in_block, sudo_call, xt,
+		OpaqueCall,
+	},
 };
 use clap::ArgMatches;
+use encointer_api_client_extension::{
+	set_api_extrisic_params_builder, CommunitiesApi, ParentchainExtrinsicSigner, SchedulerApi,
+};
 use encointer_primitives::communities::{CommunityIdentifier, Location};
-use encointer_api_client_extension::{set_api_extrisic_params_builder, CommunitiesApi, ParentchainExtrinsicSigner, SchedulerApi};
 
+use crate::utils::CallWrapping;
 use encointer_primitives::scheduler::CeremonyPhaseType;
 use itertools::Itertools;
 use log::{error, info, warn};
@@ -23,11 +26,10 @@ use sp_application_crypto::Ss58Codec;
 use sp_core::Pair;
 use sp_keyring::AccountKeyring;
 use substrate_api_client::ac_node_api::Metadata;
-use crate::utils::CallWrapping;
 
 pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async {
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	rt.block_on(async {
         // -----setup
         let spec_file = matches.value_of("specfile").unwrap();
         let spec = read_community_spec_from_file(spec_file);
@@ -118,8 +120,8 @@ pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
         .into()
 }
 pub fn add_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async {
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	rt.block_on(async {
         // -----setup
         let spec_file = matches.value_of("specfile").unwrap();
         let spec = read_community_spec_from_file(spec_file);
@@ -181,8 +183,8 @@ pub fn add_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
         .into()
 }
 pub fn list_communities(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async {
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	rt.block_on(async {
         let api = get_chain_api(matches).await;
         let maybe_at = matches.at_block_arg();
         if maybe_at.is_some() {
@@ -211,43 +213,43 @@ pub fn list_communities(_args: &str, matches: &ArgMatches<'_>) -> Result<(), cla
         .into()
 }
 pub fn list_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async {
-        let api = get_chain_api(matches).await;
-        let maybe_at = matches.at_block_arg();
-        let cid = api
-            .verify_cid(matches.cid_arg().expect("please supply argument --cid"), maybe_at)
-            .await;
-        println!("listing locations for cid {cid}");
-        let loc = api.get_locations(cid).await.unwrap();
-        for l in loc.iter() {
-            println!(
-                "lat: {} lon: {} (raw lat: {} lon: {})",
-                l.lat,
-                l.lon,
-                i128::decode(&mut l.lat.encode().as_slice()).unwrap(),
-                i128::decode(&mut l.lon.encode().as_slice()).unwrap()
-            );
-        }
-        Ok(())
-    })
-        .into()
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	rt.block_on(async {
+		let api = get_chain_api(matches).await;
+		let maybe_at = matches.at_block_arg();
+		let cid = api
+			.verify_cid(matches.cid_arg().expect("please supply argument --cid"), maybe_at)
+			.await;
+		println!("listing locations for cid {cid}");
+		let loc = api.get_locations(cid).await.unwrap();
+		for l in loc.iter() {
+			println!(
+				"lat: {} lon: {} (raw lat: {} lon: {})",
+				l.lat,
+				l.lon,
+				i128::decode(&mut l.lat.encode().as_slice()).unwrap(),
+				i128::decode(&mut l.lon.encode().as_slice()).unwrap()
+			);
+		}
+		Ok(())
+	})
+	.into()
 }
 
 fn create_add_location_batches(
-    metadata: &Metadata,
-    locations: Vec<Location>,
-    cid: CommunityIdentifier,
-    batch_size: u32,
-) -> Vec<Vec<AddLocationCall>>
-{
-    info!("Creating add location batches of size: {:?}", batch_size);
+	metadata: &Metadata,
+	locations: Vec<Location>,
+	cid: CommunityIdentifier,
+	batch_size: u32,
+) -> Vec<Vec<AddLocationCall>> {
+	info!("Creating add location batches of size: {:?}", batch_size);
 
-    locations.into_iter()
-        .skip(1) // Skip the first location
-        .map(|l| add_location_call(metadata, cid, l))
-        .chunks(batch_size as usize)
-        .into_iter()
-        .map(|chunk| chunk.collect())
-        .collect() // Collect all batches into a Vec of Vecs
+	locations
+		.into_iter()
+		.skip(1) // Skip the first location
+		.map(|l| add_location_call(metadata, cid, l))
+		.chunks(batch_size as usize)
+		.into_iter()
+		.map(|chunk| chunk.collect())
+		.collect() // Collect all batches into a Vec of Vecs
 }

--- a/client/src/commands/encointer_communities.rs
+++ b/client/src/commands/encointer_communities.rs
@@ -46,6 +46,8 @@ pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
         let add_location_calls = spec.locations().into_iter().skip(1).map(|l| add_location_call(api.metadata(), cid, l)).collect();
         let mut add_location_batch_call = OpaqueCall::from_tuple(&batch_call(api.metadata(), add_location_calls));
 
+        info!("XT call wrapping: {:?}", matches.wrap_call());
+
         (new_community_call, add_location_batch_call) = match matches.wrap_call() {
             CallWrapping::None => {
                 (new_community_call, add_location_batch_call)

--- a/client/src/commands/encointer_communities.rs
+++ b/client/src/commands/encointer_communities.rs
@@ -1,19 +1,19 @@
 use crate::{
-    cli_args::EncointerArgsExtractor,
-    community_spec::{
-        add_location_call, new_community_call, read_community_spec_from_file, AddLocationCall,
-        CommunitySpec,
-    },
-    exit_code,
-    utils::{
-        batch_call, collective_propose_call, contains_sudo_pallet, get_chain_api, get_councillors,
-        keys::get_pair_from_str, print_raw_call, send_and_wait_for_in_block, sudo_call, xt,
-        OpaqueCall,
-    },
+	cli_args::EncointerArgsExtractor,
+	community_spec::{
+		add_location_call, new_community_call, read_community_spec_from_file, AddLocationCall,
+		CommunitySpec,
+	},
+	exit_code,
+	utils::{
+		batch_call, collective_propose_call, contains_sudo_pallet, get_chain_api, get_councillors,
+		keys::get_pair_from_str, print_raw_call, send_and_wait_for_in_block, sudo_call, xt,
+		OpaqueCall,
+	},
 };
 use clap::ArgMatches;
 use encointer_api_client_extension::{
-    set_api_extrisic_params_builder, CommunitiesApi, ParentchainExtrinsicSigner, SchedulerApi,
+	set_api_extrisic_params_builder, CommunitiesApi, ParentchainExtrinsicSigner, SchedulerApi,
 };
 use encointer_primitives::communities::{CommunityIdentifier, Location};
 
@@ -28,8 +28,8 @@ use sp_keyring::AccountKeyring;
 use substrate_api_client::ac_node_api::Metadata;
 
 pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async {
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	rt.block_on(async {
         // -----setup
         let spec_file = matches.value_of("specfile").unwrap();
         let spec = read_community_spec_from_file(spec_file);
@@ -121,8 +121,8 @@ pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
         .into()
 }
 pub fn add_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async {
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	rt.block_on(async {
         // -----setup
         let spec_file = matches.value_of("specfile").unwrap();
         let spec = read_community_spec_from_file(spec_file);
@@ -184,8 +184,8 @@ pub fn add_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
         .into()
 }
 pub fn list_communities(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async {
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	rt.block_on(async {
         let api = get_chain_api(matches).await;
         let maybe_at = matches.at_block_arg();
         if maybe_at.is_some() {
@@ -214,44 +214,44 @@ pub fn list_communities(_args: &str, matches: &ArgMatches<'_>) -> Result<(), cla
         .into()
 }
 pub fn list_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async {
-        let api = get_chain_api(matches).await;
-        let maybe_at = matches.at_block_arg();
-        let cid = api
-            .verify_cid(matches.cid_arg().expect("please supply argument --cid"), maybe_at)
-            .await;
-        println!("listing locations for cid {cid}");
-        let loc = api.get_locations(cid).await.unwrap();
-        for l in loc.iter() {
-            println!(
-                "lat: {} lon: {} (raw lat: {} lon: {})",
-                l.lat,
-                l.lon,
-                i128::decode(&mut l.lat.encode().as_slice()).unwrap(),
-                i128::decode(&mut l.lon.encode().as_slice()).unwrap()
-            );
-        }
-        Ok(())
-    })
-        .into()
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	rt.block_on(async {
+		let api = get_chain_api(matches).await;
+		let maybe_at = matches.at_block_arg();
+		let cid = api
+			.verify_cid(matches.cid_arg().expect("please supply argument --cid"), maybe_at)
+			.await;
+		println!("listing locations for cid {cid}");
+		let loc = api.get_locations(cid).await.unwrap();
+		for l in loc.iter() {
+			println!(
+				"lat: {} lon: {} (raw lat: {} lon: {})",
+				l.lat,
+				l.lon,
+				i128::decode(&mut l.lat.encode().as_slice()).unwrap(),
+				i128::decode(&mut l.lon.encode().as_slice()).unwrap()
+			);
+		}
+		Ok(())
+	})
+	.into()
 }
 
 fn create_add_location_batches(
-    metadata: &Metadata,
-    locations: Vec<Location>,
-    cid: CommunityIdentifier,
-    batch_size: u32,
+	metadata: &Metadata,
+	locations: Vec<Location>,
+	cid: CommunityIdentifier,
+	batch_size: u32,
 ) -> Vec<BatchCall<AddLocationCall>> {
-    info!("Creating add location batches of size: {:?}", batch_size);
+	info!("Creating add location batches of size: {:?}", batch_size);
 
-    locations
-        .into_iter()
-        .skip(1) // Skip the first location
-        .map(|l| add_location_call(metadata, cid, l))
-        .chunks(batch_size as usize)
-        .into_iter()
-        .map(|chunk| chunk.collect())
-        .map(|b| batch_call(metadata, b))
-        .collect() // Collect all batches into a Vec of BatchCall
+	locations
+		.into_iter()
+		.skip(1) // Skip the first location
+		.map(|l| add_location_call(metadata, cid, l))
+		.chunks(batch_size as usize)
+		.into_iter()
+		.map(|chunk| chunk.collect())
+		.map(|b| batch_call(metadata, b))
+		.collect() // Collect all batches into a Vec of BatchCall
 }

--- a/client/src/commands/encointer_communities.rs
+++ b/client/src/commands/encointer_communities.rs
@@ -75,7 +75,7 @@ pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
             }
         };
 
-        if matches.should_send_tx() {
+        if !matches.dryrun_flag() {
             info!("Sending transactions");
         } else {
             info!("skipping sending transactions");

--- a/client/src/commands/encointer_communities.rs
+++ b/client/src/commands/encointer_communities.rs
@@ -1,23 +1,23 @@
 use crate::{
-	cli_args::EncointerArgsExtractor,
-	community_spec::{
-		add_location_call, new_community_call, read_community_spec_from_file, AddLocationCall,
-		CommunitySpec,
-	},
-	exit_code,
-	utils::{
-		batch_call, collective_propose_call, contains_sudo_pallet, get_chain_api, get_councillors,
-		keys::get_pair_from_str, print_raw_call, send_and_wait_for_in_block, sudo_call, xt,
-		OpaqueCall,
-	},
+    cli_args::EncointerArgsExtractor,
+    community_spec::{
+        add_location_call, new_community_call, read_community_spec_from_file, AddLocationCall,
+        CommunitySpec,
+    },
+    exit_code,
+    utils::{
+        batch_call, collective_propose_call, contains_sudo_pallet, get_chain_api, get_councillors,
+        keys::get_pair_from_str, print_raw_call, send_and_wait_for_in_block, sudo_call, xt,
+        OpaqueCall,
+    },
 };
 use clap::ArgMatches;
 use encointer_api_client_extension::{
-	set_api_extrisic_params_builder, CommunitiesApi, ParentchainExtrinsicSigner, SchedulerApi,
+    set_api_extrisic_params_builder, CommunitiesApi, ParentchainExtrinsicSigner, SchedulerApi,
 };
 use encointer_primitives::communities::{CommunityIdentifier, Location};
 
-use crate::utils::CallWrapping;
+use crate::utils::{BatchCall, CallWrapping};
 use encointer_primitives::scheduler::CeremonyPhaseType;
 use itertools::Itertools;
 use log::{error, info, warn};
@@ -28,8 +28,8 @@ use sp_keyring::AccountKeyring;
 use substrate_api_client::ac_node_api::Metadata;
 
 pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
-	let rt = tokio::runtime::Runtime::new().unwrap();
-	rt.block_on(async {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
         // -----setup
         let spec_file = matches.value_of("specfile").unwrap();
         let spec = read_community_spec_from_file(spec_file);
@@ -46,14 +46,13 @@ pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
         // ------- create calls for xt's
         let new_community_call = OpaqueCall::from_tuple(&new_community_call(&spec, api.metadata()));
         // only the first meetup location has been registered now. register all others one-by-one
-        let add_location_calls = create_add_location_batches(api.metadata(), spec.locations(), cid, matches.batch_size_arg());
-        let add_location_batch_call = add_location_calls.into_iter().map(|call| OpaqueCall::from_tuple(&batch_call(api.metadata(), call)));
+        let add_location_batch_calls = create_add_location_batches(api.metadata(), spec.locations(), cid, matches.batch_size_arg());
 
         info!("XT call wrapping: {:?}", matches.wrap_call_arg());
 
         let (new_community_final_call, add_location_batch_final_call) = match matches.wrap_call_arg() {
             CallWrapping::None => {
-                (new_community_call, add_location_batch_call.collect::<Vec<_>>())
+                (new_community_call, add_location_batch_calls.into_iter().map(|c| OpaqueCall::from_tuple(&c)).collect::<Vec<_>>())
             }
             CallWrapping::Sudo => {
                 if !contains_sudo_pallet(api.metadata()) {
@@ -61,7 +60,7 @@ pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
                 }
 
                 let sudo_new_community = sudo_call(api.metadata(), new_community_call);
-                let sudo_add_location_batch = add_location_batch_call.map(|call| sudo_call(api.metadata(), call)).collect::<Vec<_>>();
+                let sudo_add_location_batch = add_location_batch_calls.into_iter().map(|call| sudo_call(api.metadata(), call)).collect::<Vec<_>>();
                 info!("Printing raw sudo calls for js/apps for cid: {}", cid);
                 print_raw_call("sudo(new_community)", &sudo_new_community);
 
@@ -80,7 +79,8 @@ pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
                 print_raw_call("collective_propose(new_community)", &propose_new_community);
 
 
-                let propose_add_location_batch = add_location_batch_call
+                let propose_add_location_batch = add_location_batch_calls
+                    .into_iter()
                     .map(|call| collective_propose_call(api.metadata(), threshold, call)).collect::<Vec<_>>();
 
                 for call in propose_add_location_batch.iter() {
@@ -121,8 +121,8 @@ pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
         .into()
 }
 pub fn add_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
-	let rt = tokio::runtime::Runtime::new().unwrap();
-	rt.block_on(async {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
         // -----setup
         let spec_file = matches.value_of("specfile").unwrap();
         let spec = read_community_spec_from_file(spec_file);
@@ -184,8 +184,8 @@ pub fn add_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
         .into()
 }
 pub fn list_communities(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
-	let rt = tokio::runtime::Runtime::new().unwrap();
-	rt.block_on(async {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
         let api = get_chain_api(matches).await;
         let maybe_at = matches.at_block_arg();
         if maybe_at.is_some() {
@@ -214,43 +214,44 @@ pub fn list_communities(_args: &str, matches: &ArgMatches<'_>) -> Result<(), cla
         .into()
 }
 pub fn list_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
-	let rt = tokio::runtime::Runtime::new().unwrap();
-	rt.block_on(async {
-		let api = get_chain_api(matches).await;
-		let maybe_at = matches.at_block_arg();
-		let cid = api
-			.verify_cid(matches.cid_arg().expect("please supply argument --cid"), maybe_at)
-			.await;
-		println!("listing locations for cid {cid}");
-		let loc = api.get_locations(cid).await.unwrap();
-		for l in loc.iter() {
-			println!(
-				"lat: {} lon: {} (raw lat: {} lon: {})",
-				l.lat,
-				l.lon,
-				i128::decode(&mut l.lat.encode().as_slice()).unwrap(),
-				i128::decode(&mut l.lon.encode().as_slice()).unwrap()
-			);
-		}
-		Ok(())
-	})
-	.into()
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let api = get_chain_api(matches).await;
+        let maybe_at = matches.at_block_arg();
+        let cid = api
+            .verify_cid(matches.cid_arg().expect("please supply argument --cid"), maybe_at)
+            .await;
+        println!("listing locations for cid {cid}");
+        let loc = api.get_locations(cid).await.unwrap();
+        for l in loc.iter() {
+            println!(
+                "lat: {} lon: {} (raw lat: {} lon: {})",
+                l.lat,
+                l.lon,
+                i128::decode(&mut l.lat.encode().as_slice()).unwrap(),
+                i128::decode(&mut l.lon.encode().as_slice()).unwrap()
+            );
+        }
+        Ok(())
+    })
+        .into()
 }
 
 fn create_add_location_batches(
-	metadata: &Metadata,
-	locations: Vec<Location>,
-	cid: CommunityIdentifier,
-	batch_size: u32,
-) -> Vec<Vec<AddLocationCall>> {
-	info!("Creating add location batches of size: {:?}", batch_size);
+    metadata: &Metadata,
+    locations: Vec<Location>,
+    cid: CommunityIdentifier,
+    batch_size: u32,
+) -> Vec<BatchCall<AddLocationCall>> {
+    info!("Creating add location batches of size: {:?}", batch_size);
 
-	locations
-		.into_iter()
-		.skip(1) // Skip the first location
-		.map(|l| add_location_call(metadata, cid, l))
-		.chunks(batch_size as usize)
-		.into_iter()
-		.map(|chunk| chunk.collect())
-		.collect() // Collect all batches into a Vec of Vecs
+    locations
+        .into_iter()
+        .skip(1) // Skip the first location
+        .map(|l| add_location_call(metadata, cid, l))
+        .chunks(batch_size as usize)
+        .into_iter()
+        .map(|chunk| chunk.collect())
+        .map(|b| batch_call(metadata, b))
+        .collect() // Collect all batches into a Vec of BatchCall
 }

--- a/client/src/commands/encointer_communities.rs
+++ b/client/src/commands/encointer_communities.rs
@@ -77,10 +77,11 @@ pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
                 let threshold = (get_councillors(&api).await.unwrap().len() / 2 + 1) as u32;
                 info!("Printing raw collective propose calls with threshold {} for js/apps for cid: {}", threshold, cid);
                 let propose_new_community = collective_propose_call(api.metadata(), threshold, new_community_call);
-                let propose_add_location_batch = add_location_batch_call
-                    .into_iter()
-                    .map(|call| collective_propose_call(api.metadata(), threshold, call)).collect::<Vec<_>>();
                 print_raw_call("collective_propose(new_community)", &propose_new_community);
+
+
+                let propose_add_location_batch = add_location_batch_call
+                    .map(|call| collective_propose_call(api.metadata(), threshold, call)).collect::<Vec<_>>();
 
                 for call in propose_add_location_batch.iter() {
                     print_raw_call("collective_propose(utility_batch(add_location))", &call);

--- a/client/src/commands/frame.rs
+++ b/client/src/commands/frame.rs
@@ -90,5 +90,5 @@ async fn reasonable_native_balance(api: &Api) -> u128 {
 		.base_fee;
 	let ed = api.get_existential_deposit().await.unwrap();
 	// on the parachain we need this factor of 100 for some reason.
-	ed + fee * PREFUNDING_NR_OF_TRANSFER_EXTRINSICS * 100
+	ed + fee * PREFUNDING_NR_OF_TRANSFER_EXTRINSICS * 1000
 }

--- a/client/src/commands/frame.rs
+++ b/client/src/commands/frame.rs
@@ -89,5 +89,5 @@ async fn reasonable_native_balance(api: &Api) -> u128 {
 		.unwrap()
 		.base_fee;
 	let ed = api.get_existential_deposit().await.unwrap();
-	ed + fee * PREFUNDING_NR_OF_TRANSFER_EXTRINSICS
+	ed + fee * PREFUNDING_NR_OF_TRANSFER_EXTRINSICS * 100
 }

--- a/client/src/commands/frame.rs
+++ b/client/src/commands/frame.rs
@@ -89,5 +89,6 @@ async fn reasonable_native_balance(api: &Api) -> u128 {
 		.unwrap()
 		.base_fee;
 	let ed = api.get_existential_deposit().await.unwrap();
+	// on the parachain we need this factor of 100 for some reason.
 	ed + fee * PREFUNDING_NR_OF_TRANSFER_EXTRINSICS * 100
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -225,7 +225,7 @@ fn main() {
 		                    .help("enhanced geojson file that specifies a community"),
 		            )
 		            .signer_arg("account with necessary privileges")
-						.should_send_tx()
+						.dryrun_flag()
 						.wrap_call()
 		        })
 		        .runner(commands::encointer_communities::new_community),

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -225,6 +225,8 @@ fn main() {
 		                    .help("enhanced geojson file that specifies a community"),
 		            )
 		            .signer_arg("account with necessary privileges")
+						.should_send_tx()
+						.wrap_call()
 		        })
 		        .runner(commands::encointer_communities::new_community),
 		)

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -226,7 +226,8 @@ fn main() {
 		            )
 		            .signer_arg("account with necessary privileges")
 						.dryrun_flag()
-						.wrap_call()
+						.wrap_call_arg()
+						.batch_size_arg()
 		        })
 		        .runner(commands::encointer_communities::new_community),
 		)

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -49,6 +49,7 @@ pub fn batch_call<C: Encode + Clone>(metadata: &Metadata, calls: Vec<C>) -> ([u8
 	compose_call!(metadata, "Utility", "batch", calls).unwrap()
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Ord, PartialOrd)]
 pub enum CallWrapping {
 	None,
 	Sudo,

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -44,8 +44,9 @@ pub fn sudo_call<C: Encode + Clone>(metadata: &Metadata, call: C) -> ([u8; 2], C
 	compose_call!(metadata, "Sudo", "sudo", call).unwrap()
 }
 
+pub type BatchCall<C> = ([u8; 2], Vec<C>);
 /// Wraps the supplied calls in a batch call
-pub fn batch_call<C: Encode + Clone>(metadata: &Metadata, calls: Vec<C>) -> ([u8; 2], Vec<C>) {
+pub fn batch_call<C: Encode + Clone>(metadata: &Metadata, calls: Vec<C>) -> BatchCall<C> {
 	compose_call!(metadata, "Utility", "batch", calls).unwrap()
 }
 

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use crate::{
 	commands::encointer_core::{get_asset_fee_details, get_community_balance},
 	exit_code, BalanceType,
@@ -11,6 +10,7 @@ use log::{debug, error, info};
 use parity_scale_codec::{Compact, Encode};
 use sp_core::H256;
 use sp_runtime::traits::Convert;
+use std::str::FromStr;
 use substrate_api_client::{
 	ac_compose_macros::compose_call,
 	ac_node_api::Metadata,


### PR DESCRIPTION
### Main Changes:
* Instead of implicitly deciding that a sudo/collective call should be composed based on the absence of the signer arg, we do now explicitly add a CLI arg to decide if the new-community call should be wrapped or not.
* additionally, we also explicitly check if the transaction should be sent or not via the dry run flag

### There were other smaller fixes necessary for the parachain:
* The tx weight of the parachain is much bigger. I could only batch around 7 add_location calls for a successful proposal. I made this configurable via the `-b` or `--batch-size` CLI argument for now, which defaults to 100 so that it is not a breaking change. Note: Interestingly, the error I got for too many locations was misleading:
   * way too many locations: -> TX would exhaust block limit
   * a little bit too much: -> invalid proposal weight (very misleading error)
* For some reason the faucet amount was off, I could only send around 1 transaction with the `reasonable_balance`. I just added a factor of 100 for now, and decided to not care about it.

Note: I only fixed the `new-community` command. `add-location` should have the same logic in the future with respect to wrapping, batching and dry-running the extrinsic, but I thought this should come with a minor refactoring: https://github.com/encointer/encointer-node/issues/388

I manually tested bootstrapping and the bot-community against the parachain, and it works 🥳.