### PR TITLE
new community call waits for finalized

### DIFF
--- a/client/src/commands/encointer_communities.rs
+++ b/client/src/commands/encointer_communities.rs
@@ -17,7 +17,7 @@ use encointer_api_client_extension::{
 };
 use encointer_primitives::communities::{CommunityIdentifier, Location};
 
-use crate::utils::{BatchCall, CallWrapping};
+use crate::utils::{send_and_wait_for_finalized, BatchCall, CallWrapping};
 use encointer_primitives::scheduler::CeremonyPhaseType;
 use itertools::Itertools;
 use log::{error, info, warn};
@@ -104,7 +104,7 @@ pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
         let tx_payment_cid_arg = matches.tx_payment_cid_arg();
         set_api_extrisic_params_builder(&mut api, tx_payment_cid_arg).await;
 
-        send_and_wait_for_in_block(&api, xt(&api, new_community_final_call).await, matches.tx_payment_cid_arg()).await;
+        send_and_wait_for_finalized(&api, xt(&api, new_community_final_call).await, matches.tx_payment_cid_arg()).await;
         println!("{cid}");
 
         if api.get_current_phase(None).await.unwrap() != CeremonyPhaseType::Registering {
@@ -114,7 +114,7 @@ pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
         }
 
         for call in add_location_batch_final_call {
-            send_and_wait_for_in_block(&api, xt(&api, call).await, tx_payment_cid_arg).await;
+            send_and_wait_for_finalized(&api, xt(&api, call).await, tx_payment_cid_arg).await;
         }
         Ok(())
     })

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -110,6 +110,17 @@ pub async fn send_and_wait_for_in_block<C: Encode>(
 	Some(report.extrinsic_hash)
 }
 
+pub async fn send_and_wait_for_finalized<C: Encode>(
+	api: &Api,
+	xt: EncointerXt<C>,
+	tx_payment_cid: Option<&str>,
+) -> Option<H256> {
+	ensure_payment(api, &xt.encode().into(), tx_payment_cid).await;
+	let report = api.submit_and_watch_extrinsic_until(xt, XtStatus::Finalized).await.unwrap();
+	info!("[+] Transaction got finalized in Block: {:?}\n", report.block_hash.unwrap());
+	Some(report.extrinsic_hash)
+}
+
 /// Prints the raw call to be supplied with js/apps.
 pub fn print_raw_call<Call: Encode>(name: &str, call: &Call) {
 	info!("{}: 0x{}", name, hex::encode(call.encode()));


### PR DESCRIPTION
Locally, it was very stable with the omni-node. So I thought we can ommit waiting during the new-community call. But in the CI it we get constant invalid tx's at this step.