### PR TITLE
use phusion base image for encointer-node docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:jammy-1.0.4
+FROM ubuntu:22.04
 LABEL description="This is the 2nd stage: a very small image where we copy the Substrate binary."
 
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM phusion/baseimage:jammy-1.0.4
 LABEL description="This is the 2nd stage: a very small image where we copy the Substrate binary."
 
 RUN apt-get update && \

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM phusion/baseimage:jammy-1.0.4
 LABEL description="This is the 2nd stage: a very small image where we copy the Substrate binary."
 
 # Install netcat for websocket healthcheck


### PR DESCRIPTION
I didn't do the encointer-client as I got an error, and did not want to debug.