### PR TITLE
Introduce remove-location call

### DIFF
--- a/client/encointer-api-client-extension/src/communities.rs
+++ b/client/encointer-api-client-extension/src/communities.rs
@@ -5,6 +5,7 @@ use encointer_primitives::{
 	communities::{CidName, CommunityIdentifier, CommunityMetadata, Location},
 };
 use std::str::FromStr;
+use encointer_primitives::communities::GeoHash;
 use substrate_api_client::{ac_compose_macros::rpc_params, rpc::Request, GetStorage};
 
 #[maybe_async::maybe_async(?Send)]
@@ -29,6 +30,12 @@ pub trait CommunitiesApi {
 		cid: CommunityIdentifier,
 		maybe_at: Option<Hash>,
 	) -> Option<CommunityMetadata>;
+	async fn get_locations_by_geohash(
+		&self,
+		cid: CommunityIdentifier,
+		geo_hash: GeoHash,
+		maybe_at: Option<Hash>,
+	) -> Option<Vec<Location>>;
 	async fn get_cid_names(&self) -> Option<Vec<CidName>>;
 	async fn verify_cid(&self, cid: &str, maybe_at: Option<Hash>) -> CommunityIdentifier;
 }
@@ -76,6 +83,17 @@ impl CommunitiesApi for Api {
 		maybe_at: Option<Hash>,
 	) -> Option<CommunityMetadata> {
 		self.get_storage_map("EncointerCommunities", "CommunityMetadata", cid, maybe_at)
+			.await
+			.unwrap()
+	}
+
+	async fn get_locations_by_geohash(
+		&self,
+		cid: CommunityIdentifier,
+		geo_hash: GeoHash,
+		maybe_at: Option<Hash>,
+	) -> Option<Vec<Location>> {
+		self.get_storage_double_map("EncointerCommunities", "Locations", cid, geo_hash, maybe_at)
 			.await
 			.unwrap()
 	}

--- a/client/encointer-api-client-extension/src/communities.rs
+++ b/client/encointer-api-client-extension/src/communities.rs
@@ -2,10 +2,9 @@ use crate::{Api, Result};
 use encointer_node_notee_runtime::Hash;
 use encointer_primitives::{
 	balances::{BalanceType, Demurrage},
-	communities::{CidName, CommunityIdentifier, CommunityMetadata, Location},
+	communities::{CidName, CommunityIdentifier, CommunityMetadata, GeoHash, Location},
 };
 use std::str::FromStr;
-use encointer_primitives::communities::GeoHash;
 use substrate_api_client::{ac_compose_macros::rpc_params, rpc::Request, GetStorage};
 
 #[maybe_async::maybe_async(?Send)]

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -1,6 +1,7 @@
 use crate::utils::CallWrapping;
 use clap::{App, Arg, ArgMatches};
 use encointer_primitives::{balances::BalanceType, reputation_commitments::PurposeIdType};
+use encointer_primitives::communities::GeoHash;
 use sp_core::{bytes, H256 as Hash};
 
 const ACCOUNT_ARG: &str = "accountid";
@@ -9,6 +10,8 @@ const FAUCET_BENEFICIARY_ARG: &str = "faucet-beneficiary";
 const SEED_ARG: &str = "seed";
 const SIGNER_ARG: &str = "signer";
 const CID_ARG: &str = "cid";
+const GEOHASH_ARG: &str = "geohash";
+const LOCATION_INDEX_ARG: &str = "location_index";
 const ATTESTEES_ARG: &str = "attestees";
 const WHITELIST_ARG: &str = "whitelist";
 const CEREMONY_INDEX_ARG: &str = "ceremony-index";
@@ -47,6 +50,8 @@ pub trait EncointerArgs<'b> {
 	fn seed_arg(self) -> Self;
 	fn signer_arg(self, help: &'b str) -> Self;
 	fn optional_cid_arg(self) -> Self;
+	fn geohash_arg(self) -> Self;
+	fn location_index_arg(self) -> Self;
 	fn attestees_arg(self) -> Self;
 	fn whitelist_arg(self) -> Self;
 	fn ceremony_index_arg(self) -> Self;
@@ -88,6 +93,8 @@ pub trait EncointerArgsExtractor {
 	fn seed_arg(&self) -> Option<&str>;
 	fn signer_arg(&self) -> Option<&str>;
 	fn cid_arg(&self) -> Option<&str>;
+	fn geohash_arg(&self) -> Option<GeoHash>;
+	fn location_index_arg(&self) -> Option<u32>;
 	fn attestees_arg(&self) -> Option<Vec<&str>>;
 	fn whitelist_arg(&self) -> Option<Vec<&str>>;
 	fn ceremony_index_arg(&self) -> Option<i32>;
@@ -184,6 +191,30 @@ impl<'a, 'b> EncointerArgs<'b> for App<'a, 'b> {
 				.takes_value(true)
 				.value_name("STRING")
 				.help("community identifier, base58 encoded"),
+		)
+	}
+
+	fn geohash_arg(self) -> Self {
+		self.arg(
+			Arg::with_name(GEOHASH_ARG)
+				.short("g")
+				.long("geohash")
+				.global(true)
+				.takes_value(true)
+				.value_name("STRING")
+				.help("geoshash"),
+		)
+	}
+
+	fn location_index_arg(self) -> Self {
+		self.arg(
+			Arg::with_name(LOCATION_INDEX_ARG)
+				.short("l")
+				.long("location_index")
+				.global(true)
+				.takes_value(true)
+				.value_name("Index")
+				.help("location index to be removed"),
 		)
 	}
 
@@ -514,6 +545,15 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 
 	fn cid_arg(&self) -> Option<&str> {
 		self.value_of(CID_ARG)
+	}
+	
+	fn geohash_arg(&self) -> Option<GeoHash> {
+		self.value_of(GEOHASH_ARG)
+			.map(|v| GeoHash::try_from(v).unwrap())
+	}
+
+	fn location_index_arg(&self) -> Option<u32> {
+		self.value_of(LOCATION_INDEX_ARG).map(|v| v.parse().unwrap())
 	}
 
 	fn attestees_arg(&self) -> Option<Vec<&str>> {

--- a/client/src/cli_args.rs
+++ b/client/src/cli_args.rs
@@ -1,7 +1,8 @@
 use crate::utils::CallWrapping;
 use clap::{App, Arg, ArgMatches};
-use encointer_primitives::{balances::BalanceType, reputation_commitments::PurposeIdType};
-use encointer_primitives::communities::GeoHash;
+use encointer_primitives::{
+	balances::BalanceType, communities::GeoHash, reputation_commitments::PurposeIdType,
+};
 use sp_core::{bytes, H256 as Hash};
 
 const ACCOUNT_ARG: &str = "accountid";
@@ -546,10 +547,9 @@ impl<'a> EncointerArgsExtractor for ArgMatches<'a> {
 	fn cid_arg(&self) -> Option<&str> {
 		self.value_of(CID_ARG)
 	}
-	
+
 	fn geohash_arg(&self) -> Option<GeoHash> {
-		self.value_of(GEOHASH_ARG)
-			.map(|v| GeoHash::try_from(v).unwrap())
+		self.value_of(GEOHASH_ARG).map(|v| GeoHash::try_from(v).unwrap())
 	}
 
 	fn location_index_arg(&self) -> Option<u32> {

--- a/client/src/commands/encointer_communities.rs
+++ b/client/src/commands/encointer_communities.rs
@@ -17,7 +17,10 @@ use encointer_api_client_extension::{
 };
 use encointer_primitives::communities::{CommunityIdentifier, Location};
 
-use crate::utils::{send_and_wait_for_finalized, BatchCall, CallWrapping};
+use crate::{
+	community_spec::remove_location_call,
+	utils::{send_and_wait_for_finalized, BatchCall, CallWrapping},
+};
 use encointer_primitives::scheduler::CeremonyPhaseType;
 use itertools::Itertools;
 use log::{error, info, warn};
@@ -26,7 +29,6 @@ use sp_application_crypto::Ss58Codec;
 use sp_core::Pair;
 use sp_keyring::Sr25519Keyring as AccountKeyring;
 use substrate_api_client::ac_node_api::Metadata;
-use crate::community_spec::remove_location_call;
 
 pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
 	let rt = tokio::runtime::Runtime::new().unwrap();
@@ -187,8 +189,8 @@ pub fn add_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
 }
 
 pub fn remove_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async {
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	rt.block_on(async {
         // -----setup
 
         let mut api = get_chain_api(matches).await;

--- a/client/src/commands/encointer_communities.rs
+++ b/client/src/commands/encointer_communities.rs
@@ -26,6 +26,7 @@ use sp_application_crypto::Ss58Codec;
 use sp_core::Pair;
 use sp_keyring::Sr25519Keyring as AccountKeyring;
 use substrate_api_client::ac_node_api::Metadata;
+use crate::community_spec::remove_location_call;
 
 pub fn new_community(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
 	let rt = tokio::runtime::Runtime::new().unwrap();
@@ -180,6 +181,66 @@ pub fn add_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::
             send_and_wait_for_in_block(&api, xt(&api, add_location_maybe_batch_call).await, tx_payment_cid_arg).await;
         }
         Ok(())
+
+    })
+        .into()
+}
+
+pub fn remove_locations(_args: &str, matches: &ArgMatches<'_>) -> Result<(), clap::Error> {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        // -----setup
+
+        let mut api = get_chain_api(matches).await;
+        if !matches.dryrun_flag() {
+            let signer = matches.signer_arg()
+                .map_or_else(|| AccountKeyring::Alice.pair(), |signer| get_pair_from_str(signer).into());
+            info!("signer ss58 is {}", signer.public().to_ss58check());
+            let signer = ParentchainExtrinsicSigner::new(signer);
+            api.set_signer(signer);
+        }
+
+        let tx_payment_cid_arg = matches.tx_payment_cid_arg();
+
+        let cid = api.verify_cid(matches.cid_arg().unwrap(), None).await;
+        let geohash = matches.geohash_arg().expect("need geohash");
+        let location_index = matches.location_index_arg().expect("need location");
+        let locations = api.get_locations_by_geohash(cid, geohash, None).await.unwrap();
+
+        let mut remove_location_call =
+            OpaqueCall::from_tuple(
+            &remove_location_call(api.metadata(), cid, locations[location_index as usize])
+        );
+
+        if matches.signer_arg().is_none() {
+            // return calls as `OpaqueCall`s to get the same return type in both branches
+            remove_location_call = if contains_sudo_pallet(api.metadata()) {
+                let sudo_add_location_batch = sudo_call(api.metadata(), remove_location_call);
+                info!("Printing raw sudo calls for js/apps for cid: {}", cid);
+                print_raw_call("sudo(remove_location)", &sudo_add_location_batch);
+                OpaqueCall::from_tuple(&sudo_add_location_batch)
+            } else {
+                let threshold = (get_councillors(&api).await.unwrap().len() / 2 + 1) as u32;
+                info!("Printing raw collective propose calls with threshold {} for js/apps for cid: {}", threshold, cid);
+                let propose_add_location_batch = collective_propose_call(api.metadata(), threshold, remove_location_call);
+                print_raw_call("collective_propose(remove_location)", &propose_add_location_batch);
+                OpaqueCall::from_tuple(&propose_add_location_batch)
+            };
+        }
+
+        if matches.dryrun_flag() {
+            println!("0x{}", hex::encode(remove_location_call.encode()));
+        } else {
+            // ---- send xt's to chain
+            if api.get_current_phase(None).await.unwrap() != CeremonyPhaseType::Registering {
+                error!("Wrong ceremony phase for registering new locations for {}", cid);
+                error!("Aborting without registering additional locations");
+                std::process::exit(exit_code::WRONG_PHASE);
+            }
+            send_and_wait_for_in_block(&api, xt(&api, remove_location_call).await, tx_payment_cid_arg).await;
+        }
+        Ok(())
+
     })
         .into()
 }

--- a/client/src/community_spec.rs
+++ b/client/src/community_spec.rs
@@ -196,7 +196,6 @@ pub fn add_location_call(
 	compose_call!(metadata, "EncointerCommunities", "add_location", cid, loc).unwrap()
 }
 
-
 /// Create an `add_location` call to be used in an extrinsic.
 pub fn remove_location_call(
 	metadata: &Metadata,

--- a/client/src/community_spec.rs
+++ b/client/src/community_spec.rs
@@ -185,6 +185,7 @@ pub fn new_community_call<T: CommunitySpec>(spec: &T, metadata: &Metadata) -> Ne
 }
 
 pub type AddLocationCall = ([u8; 2], CommunityIdentifier, Location);
+pub type RemoveLocationCall = ([u8; 2], CommunityIdentifier, Location);
 
 /// Create an `add_location` call to be used in an extrinsic.
 pub fn add_location_call(
@@ -193,6 +194,16 @@ pub fn add_location_call(
 	loc: Location,
 ) -> AddLocationCall {
 	compose_call!(metadata, "EncointerCommunities", "add_location", cid, loc).unwrap()
+}
+
+
+/// Create an `add_location` call to be used in an extrinsic.
+pub fn remove_location_call(
+	metadata: &Metadata,
+	cid: CommunityIdentifier,
+	loc: Location,
+) -> RemoveLocationCall {
+	compose_call!(metadata, "EncointerCommunities", "remove_location", cid, loc).unwrap()
 }
 
 pub fn demurrage_per_block_from_halving_blocks(halving_blocks: u64) -> Demurrage {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -248,6 +248,19 @@ fn main() {
 		        .runner(commands::encointer_communities::add_locations),
 		)
 		.add_cmd(
+			Command::new("remove-location")
+				.description("Remove a location a for a community. Check polkadot-js/apps to find the geohash")
+				.options(|app| {
+					app.setting(AppSettings::ColoredHelp)
+						.signer_arg("account with necessary privileges")
+						.dryrun_flag()
+						.optional_cid_arg()
+						.geohash_arg()
+						.location_index_arg()
+				})
+				.runner(commands::encointer_communities::remove_locations),
+		)
+		.add_cmd(
 		    Command::new("list-communities")
 		        .description("list all registered communities")
 				.options(|app| {


### PR DESCRIPTION
The geo hash in question can be found out with `encointerCommunityLocations(cid, None)`. This give a nice list of locations by geohash. I kind of thought that it is easier to use the storage instead of the custom-rpc in this case. Not sure if it is true.


```
// cid, geohash, location_index
nctr-k remove-location --dryrun --cid s1vrqQL2SD -g s1rgt -l 0
0x3202103e0273317672710fbc30420000d897382798a607000000000000000000e8e91d4883260b00000000000000bc
```

Sanity check:
- [x] I verified that the generated [call](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fsys.ibp.network%2Fencointer-kusama#/extrinsics/decode/0x3202103e0273317672710fbc30420000d897382798a607000000000000000000e8e91d4883260b00000000000000bc) does indeed want to remove the location that I intended.