### PR TITLE
Add cross-chain replay protection for offline payments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,7 +2884,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2900,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment-rpc"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-balances-tx-payment-rpc-runtime-api",
  "encointer-primitives",
@@ -2924,7 +2924,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment-rpc-runtime-api"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "encointer-ceremonies-assignment"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -2989,7 +2989,7 @@ dependencies = [
 [[package]]
 name = "encointer-meetup-validation"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -3128,7 +3128,7 @@ dependencies = [
 [[package]]
 name = "encointer-primitives"
 version = "21.5.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "bs58",
  "crc",
@@ -3148,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "encointer-rpc"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "jsonrpsee 0.24.10",
  "jsonrpsee-core 0.24.10",
@@ -3271,7 +3271,7 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 [[package]]
 name = "ep-core"
 version = "21.0.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "array-bytes 6.2.3",
  "impl-serde",
@@ -7144,7 +7144,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-balances"
 version = "21.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -7180,7 +7180,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -7200,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -7212,7 +7212,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-meetup-validation",
@@ -7237,7 +7237,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -7257,7 +7257,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -7269,7 +7269,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -7309,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -7320,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-democracy"
 version = "21.6.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -7345,7 +7345,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-faucet"
 version = "21.2.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -7365,7 +7365,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-offline-payment"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "ark-bn254",
  "ark-crypto-primitives",
@@ -7395,7 +7395,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-reputation-commitments"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -7417,7 +7417,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-scheduler"
 version = "21.1.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -7435,7 +7435,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-treasuries"
 version = "21.7.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -7457,7 +7457,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-treasuries-rpc"
 version = "21.3.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -7479,7 +7479,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-treasuries-rpc-runtime-api"
 version = "21.3.0"
-source = "git+https://github.com/encointer/pallets?branch=master#4e34e7ca9bda4d9b09515f56c9cd9f7e381047d5"
+source = "git+https://github.com/encointer/pallets?branch=master#a43ca61a26dba091c7c52d8ce6e6e8c8db9527a3"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -8854,7 +8854,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8874,7 +8874,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -15240,7 +15240,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "pallet-encointer-offline-payment"
-version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ ac-keystore = { version = "1.21.0" }
 #pallet-encointer-faucet = { path = "../encointer-pallets/faucet" }
 #pallet-encointer-reputation-commitments = { path = "../encointer-pallets/reputation-commitments" }
 #pallet-encointer-scheduler = { path = "../encointer-pallets/scheduler" }
-pallet-encointer-offline-payment = { path = "../encointer-pallets/offline-payment" }
+#pallet-encointer-offline-payment = { path = "../encointer-pallets/offline-payment" }
 #pallet-encointer-treasuries = { path = "../encointer-pallets/treasuries" }
 #pallet-encointer-treasuries-rpc = { path = "../encointer-pallets/treasuries/rpc" }
 #pallet-encointer-treasuries-rpc-runtime-api = { path = "../encointer-pallets/treasuries/rpc/runtime-api" }
@@ -193,7 +193,7 @@ pallet-encointer-communities-rpc = { git = "https://github.com/encointer/pallets
 pallet-encointer-communities-rpc-runtime-api = { git = "https://github.com/encointer/pallets", branch = "master" }
 pallet-encointer-democracy = { git = "https://github.com/encointer/pallets", branch = "master" }
 pallet-encointer-faucet = { git = "https://github.com/encointer/pallets", branch = "master" }
-#pallet-encointer-offline-payment = { git = "https://github.com/encointer/pallets", branch = "master" }
+pallet-encointer-offline-payment = { git = "https://github.com/encointer/pallets", branch = "master" }
 pallet-encointer-reputation-commitments = { git = "https://github.com/encointer/pallets", branch = "master" }
 pallet-encointer-scheduler = { git = "https://github.com/encointer/pallets", branch = "master" }
 pallet-encointer-treasuries = { git = "https://github.com/encointer/pallets", branch = "master" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -566,6 +566,7 @@ parameter_types! {
 impl pallet_encointer_offline_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = weights::pallet_encointer_offline_payment::WeightInfo<Runtime>;
+	type Currency = Balances;
 	type MaxProofSize = MaxProofSize;
 	type MaxVkSize = MaxVkSize;
 }

--- a/runtime/src/weights/pallet_encointer_offline_payment.rs
+++ b/runtime/src/weights/pallet_encointer_offline_payment.rs
@@ -41,6 +41,13 @@ impl<T: frame_system::Config> pallet_encointer_offline_payment::WeightInfo for W
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
 
+	fn submit_native_offline_payment() -> Weight {
+		// Same ZK proof verification cost as CC variant
+		Weight::from_parts(500_000_000, 0)
+			.saturating_add(T::DbWeight::get().reads(4))
+			.saturating_add(T::DbWeight::get().writes(2))
+	}
+
 	fn set_verification_key() -> Weight {
 		Weight::from_parts(100_000_000, 0)
 			.saturating_add(T::DbWeight::get().writes(1))


### PR DESCRIPTION
## Summary

- Client proof generation chain-binds asset hash with genesis hash (`chain_asset_hash = blake2_256(asset_hash ++ genesis_hash)`) to prevent cross-chain proof replay, matching pallets PR encointer/pallets#444
- Renames `cid_hash` → `asset_hash` / `chain_asset_hash` in client code
- Updates pallets dependency to latest master (includes cross-chain replay protection + native offline payment support)
- Adds `type Currency = Balances` to runtime config (new pallet requirement)
- Adds `submit_native_offline_payment` weight stub

## Test plan

- [x] `SKIP_WASM_BUILD=1 cargo check --workspace --all-targets --all-features` passes
- [x] `SKIP_WASM_BUILD=1 cargo clippy --workspace --all-targets --all-features` — no new warnings
- [x] `cargo +nightly fmt --all -- --check` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)