### PR TITLE
support unlinkable pop contexts

### DIFF
--- a/cli/py_client/reputation_rings_mixin.py
+++ b/cli/py_client/reputation_rings_mixin.py
@@ -25,12 +25,13 @@ class _ReputationRingsMixin:
         ret = self.run_cli_command(["personhood", "ring", "get", "--ceremony-index", str(ceremony_index)], cid=cid)
         return ret.stdout.decode("utf-8").strip()
 
-    def prove_personhood(self, account, cid, ceremony_index, level=1, sub_ring=0):
+    def prove_personhood(self, account, cid, ceremony_index, level=1, sub_ring=0, context="encointer-pop"):
         ret = self.run_cli_command([
             "personhood", "prove-ring-membership", account,
             "--ceremony-index", str(ceremony_index),
             "--level", str(level),
             "--sub-ring", str(sub_ring),
+            "--context", context,
         ], cid=cid)
         ensure_clean_exit(ret)
         output = ret.stdout.decode("utf-8").strip()
@@ -40,13 +41,14 @@ class _ReputationRingsMixin:
                 return line.split(maxsplit=1)[1].strip(), output
         raise RuntimeError(f"prove-personhood did not return a signature: {output}")
 
-    def verify_personhood(self, signature, cid, ceremony_index, level=1, sub_ring=0):
+    def verify_personhood(self, signature, cid, ceremony_index, level=1, sub_ring=0, context="encointer-pop"):
         ret = self.run_cli_command([
             "personhood", "verify-ring-membership",
             "--signature", signature,
             "--ceremony-index", str(ceremony_index),
             "--level", str(level),
             "--sub-ring", str(sub_ring),
+            "--context", context,
         ], cid=cid)
         output = ret.stdout.decode("utf-8").strip()
         return "VALID" in output, output

--- a/cli/src/cli/personhood.rs
+++ b/cli/src/cli/personhood.rs
@@ -20,6 +20,9 @@ pub enum PersonhoodCmd {
 		/// Sub-ring index
 		#[arg(long = "sub-ring", default_value = "0")]
 		sub_ring: u32,
+		/// Application context for domain separation (different contexts yield unlinkable pseudonyms)
+		#[arg(long, default_value = "encointer-pop")]
+		context: String,
 	},
 	/// Verify ring-VRF proof of personhood
 	VerifyRingMembership {
@@ -35,6 +38,9 @@ pub enum PersonhoodCmd {
 		/// Sub-ring index
 		#[arg(long = "sub-ring", default_value = "0")]
 		sub_ring: u32,
+		/// Application context for domain separation (must match the context used for signing)
+		#[arg(long, default_value = "encointer-pop")]
+		context: String,
 	},
 	/// Reputation commitment commands
 	#[command(subcommand)]
@@ -81,22 +87,30 @@ impl PersonhoodCmd {
 		use crate::commands::encointer_reputation_rings;
 		match self {
 			Self::Ring(cmd) => cmd.run(cli).await,
-			Self::ProveRingMembership { account, ceremony_index, level, sub_ring } =>
+			Self::ProveRingMembership { account, ceremony_index, level, sub_ring, context } =>
 				encointer_reputation_rings::prove_personhood(
 					cli,
 					account,
 					*ceremony_index,
 					*level,
 					*sub_ring,
+					context,
 				)
 				.await,
-			Self::VerifyRingMembership { signature, ceremony_index, level, sub_ring } =>
+			Self::VerifyRingMembership {
+				signature,
+				ceremony_index,
+				level,
+				sub_ring,
+				context,
+			} =>
 				encointer_reputation_rings::verify_personhood(
 					cli,
 					signature,
 					*ceremony_index,
 					*level,
 					*sub_ring,
+					context,
 				)
 				.await,
 			Self::Commitment(cmd) => cmd.run(cli).await,

--- a/cli/src/cli/personhood.rs
+++ b/cli/src/cli/personhood.rs
@@ -97,13 +97,7 @@ impl PersonhoodCmd {
 					context,
 				)
 				.await,
-			Self::VerifyRingMembership {
-				signature,
-				ceremony_index,
-				level,
-				sub_ring,
-				context,
-			} =>
+			Self::VerifyRingMembership { signature, ceremony_index, level, sub_ring, context } =>
 				encointer_reputation_rings::verify_personhood(
 					cli,
 					signature,


### PR DESCRIPTION
add a user parameter to the deterministic ring-VRF to bind proofs to a context but make proofs for different contexts for the same ring mutually unlinkable